### PR TITLE
[DM-25393] Run the action on an older Ubuntu

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.1


### PR DESCRIPTION
The chart release action is not correctly detecting the last tag,
which appears to be due to a Git behavior change.  Try using an
old version of Ubuntu to see if that works around the problem.