### PR TITLE
[DM-25393] Don't use shallow clones for release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.1
+        with:
+          fetch_depth: 0
 
       - name: Configure Git
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.1


### PR DESCRIPTION
checkout now does shallow clones by default, which breaks the
logic for finding changes since the previous tag.  Disable that.