### PR TITLE
Add exec:admin to the Gafaelfawr known scopes

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.3.3
+version: 1.3.4
 description: The Gafaelfawr authentication and authorization system
 home: https://github.com/lsst/gafaelfawr
-appVersion: "1.3.2"
+appVersion: 1.3.2

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -44,6 +44,7 @@ issuer:
 # the new token creation page.  Only scopes listed here will be options
 # when creating a new token.
 known_scopes:
+  "exec:admin": Administrative access to all APIs.
   "exec:portal": Use the Portal to execute operations. Mostly used from notebook APIs.
   "read:image": Read images from the SODA and other image retrieval interfaces
   "read:image/metadata": Read image metadata from SIA and other image interfaces


### PR DESCRIPTION
This allows someone with that scope to create an access token that
also has that scope, which is required by mobu.  We will want to
revisit this when we have a more comprehensive identity management
plan.

Remove unnecessary quotes from appVersion in the Gafaelfawr chart.