### PR TITLE
[DM-25844] Fix indentation of labels in neophile chart

### DIFF
--- a/charts/neophile/Chart.yaml
+++ b/charts/neophile/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: neophile
-version: 0.0.1
+version: 0.0.2
 description: Periodically check for needed dependency updates
 home: https://github.com/lsst-sqre/neophile
 appVersion: 0.0.1

--- a/charts/neophile/templates/cronjob.yaml
+++ b/charts/neophile/templates/cronjob.yaml
@@ -10,7 +10,7 @@ spec:
         metadata:
           labels:
             name: {{ template "helpers.fullname" . }}
-{{ include "helpers.labels" . | indent 8 }}
+{{ include "helpers.labels" . | indent 12 }}
         spec:
           containers:
             - name: {{ template "helpers.fullname" . }}


### PR DESCRIPTION
The template was copied from a Deployment, but a CronJob has a
different structure and requires more indentation.