### PR TITLE
[DM-25844] Add restartPolicy to neophile CronJob

### DIFF
--- a/charts/neophile/Chart.yaml
+++ b/charts/neophile/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: neophile
-version: 0.0.2
+version: 0.0.3
 description: Periodically check for needed dependency updates
 home: https://github.com/lsst-sqre/neophile
 appVersion: 0.0.1

--- a/charts/neophile/templates/cronjob.yaml
+++ b/charts/neophile/templates/cronjob.yaml
@@ -12,6 +12,7 @@ spec:
             name: {{ template "helpers.fullname" . }}
 {{ include "helpers.labels" . | indent 12 }}
         spec:
+          restartPolicy: "Never"
           containers:
             - name: {{ template "helpers.fullname" . }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
This turns out to be a required field because the default for a
Job isn't valid for a CronJob.