### PR TITLE
[DM-25844] Add neophile support for github_email parameter

### DIFF
--- a/charts/neophile/Chart.yaml
+++ b/charts/neophile/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: neophile
-version: 0.0.4
+version: 0.1.0
 description: Periodically check for needed dependency updates
 home: https://neophile.lsst.io/
 maintainers:
   - name: rra
-appVersion: 0.0.1
+appVersion: 0.1.0

--- a/charts/neophile/templates/configmap.yaml
+++ b/charts/neophile/templates/configmap.yaml
@@ -6,6 +6,9 @@ data:
   neophile.yaml: |
     allow_expressions: true
     cache_enabled: false
+    {{- if .Values.github_email }}
+    github_email: {{ .Values.github_email | quote }}
+    {{- end }}
     github_user: {{ .Values.github_user | quote }}
     repositories:
       {{- range $repository := .Values.repositories }}

--- a/charts/neophile/values.yaml
+++ b/charts/neophile/values.yaml
@@ -1,6 +1,10 @@
 # Name of the GitHub user (must match the token in the secret).
 github_user: ""
 
+# Email address to use for GitHub commits.  Leave blank to use the public
+# email address of the user.
+github_email: ""
+
 # Repositories to monitor.
 repositories: {}
 


### PR DESCRIPTION
Add github_email to the values.yaml file and the ConfigMap template.