### PR TITLE
[DM-26078] Add Gafaelfawr support for password-protected Redis

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.3.5
+version: 1.3.6
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -8,6 +8,7 @@ data:
     loglevel: {{ .Values.loglevel | quote }}
     session_secret_file: "/etc/gafaelfawr/secrets/session-secret"
     redis_url: "redis://{{ template "helpers.fullname" . }}-redis-service.{{ .Release.Namespace }}.svc.cluster.local:6379/0"
+    redis_password_file: "/etc/gafaelfawr/secrets/redis-password"
     {{- if .Values.proxies }}
     proxies:
       {{- range $netblock := .Values.proxies }}

--- a/charts/gafaelfawr/templates/redis-deployment.yml
+++ b/charts/gafaelfawr/templates/redis-deployment.yml
@@ -19,8 +19,17 @@ spec:
         image: redis
         imagePullPolicy: Always
         args:
-          - redis-server
-          - --appendonly yes
+          - "redis-server"
+          - "--appendonly"
+          - "yes"
+          - "--requirepass"
+          - "$(REDIS_PASSWORD)"
+        env:
+          - name: "REDIS_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "helpers.fullname" . }}-secret
+                key: "redis-password"
         ports:
           - containerPort: 6379
         resources:

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -12,7 +12,7 @@ ingress:
 image:
   repository: "lsstsqre/gafaelfawr"
   tag: "1.3.2"
-  pullPolicy: "Always"
+  pullPolicy: "IfNotPresent"
 
 # Existing PVC for redis claim
 # If empty, redis will use emptydir


### PR DESCRIPTION
Since we're giving users a shell into the Kubernetes private
network, add password protection to Gafaelfawr's Redis for an
additional layer of protection.

Change the pull policy for the Gafaelfawr image to IfNotPresent
since we're pulling tagged images and the tag won't move.  Users
that override this to point to a ticket branch can also override
the pull policy.