### PR TITLE
[DM-25766] Add a Redis liveness probe

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.3.6
+version: 1.3.7
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/redis-deployment.yml
+++ b/charts/gafaelfawr/templates/redis-deployment.yml
@@ -17,7 +17,8 @@ spec:
       containers:
       - name: redis
         image: redis
-        imagePullPolicy: Always
+        imagePullPolicy: "Always"
+        restartPolicy: "OnFailure"
         args:
           - "redis-server"
           - "--appendonly"
@@ -35,6 +36,14 @@ spec:
         resources:
           limits:
             cpu: "1"
+        livenessProbe:
+          exec:
+            command:
+              - "sh"
+              - "-c"
+              - "redis-cli -h $(hostname) incr health:counter"
+          initialDelaySeconds: 15
+          periodSeconds: 30
         volumeMounts:
           - name: redis-data
             mountPath: "/data"


### PR DESCRIPTION
Every thirty seconds, make sure that Redis can write to its
database.  This will catch problems we've seen in the past where
the NFS mount for the persistent volume goes read-only due to NCSA
disk issues.  If that happens with this probe, the container will
be killed and restarted, which is the correct action to take to
recover.

Set the restart policy to OnFailure to allow for this restart.