### PR TITLE
[DM-26072] Add Gafaelfawr support for InfluxDB and Chronograf

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.3.7
+version: 1.4.0
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:
   - name: rra
-appVersion: 1.3.2
+appVersion: 1.4.0

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -25,6 +25,9 @@ data:
         internal: "https://{{ .Values.host }}/api"
       key_file: "/etc/gafaelfawr/secrets/signing-key"
       exp_minutes: {{ .Values.issuer.exp_minutes }}
+      {{- if .Values.issuer.influxdb.enabled }}
+      influxdb_secret_file: "/etc/gafaelfawr/secrets/influxdb-secret"
+      {{- end }}
 
     {{- if .Values.github }}
 
@@ -58,6 +61,10 @@ data:
       key_ids:
         - "244B235F6B28E34108D101EAC7362C4E"
 
+    {{- end }}
+
+    {{- if .Values.oidc_server.enabled }}
+    oidc_server_secrets_file: "/etc/gafaelfawr/secrets/oidc-server-secrets"
     {{- end }}
 
     known_scopes:

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -11,7 +11,7 @@ ingress:
 # Docker image to use.
 image:
   repository: "lsstsqre/gafaelfawr"
-  tag: "1.3.2"
+  tag: "1.4.0"
   pullPolicy: "IfNotPresent"
 
 # Existing PVC for redis claim
@@ -36,9 +36,19 @@ proxies:
   - "172.16.0.0/12"
   - "192.168.0.0/16"
 
-# Session length and token expiration (in minutes).
 issuer:
+  # Session length and token expiration (in minutes).
   exp_minutes: 1440  # 1 day
+
+  # Whether to issue tokens for InfluxDB.  If set to true, influxdb-secret
+  # must be set in the Gafaelfawr secret.
+  influxdb:
+    enabled: false
+
+# Whether to support OpenID Connect clients.  If set to true,
+# oidc-server-secrets must be set in the Gafaelfawr secret.
+oidc_server:
+  enabled: false
 
 # Names and descriptions of all scopes in use.  This is used to populate
 # the new token creation page.  Only scopes listed here will be options


### PR DESCRIPTION
Add configuration settings for InfluxDB token issuance and for
the OpenID Connect server to support Chronograf, both disabled
by default.