### PR TITLE
[DM-26412] Add security hardening for Gafaelfawr

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.4.2
+version: 1.4.3
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/deployment.yaml
+++ b/charts/gafaelfawr/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         name: {{ template "helpers.fullname" . }}
 {{ include "helpers.labels" . | indent 8 }}
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: gafaelfawr
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -23,6 +24,12 @@ spec:
           ports:
             - containerPort: 8080
               name: app
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: {{ template "helpers.fullname" . }}-config
               mountPath: "/etc/gafaelfawr"
@@ -30,6 +37,10 @@ spec:
             - name: {{ template "helpers.fullname" . }}-secret
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
       volumes:
         - name: {{ template "helpers.fullname" . }}-config
           configMap:

--- a/charts/gafaelfawr/templates/redis-deployment.yaml
+++ b/charts/gafaelfawr/templates/redis-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: {{ template "helpers.fullname" . }}-redis
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: redis
           image: redis
@@ -30,11 +31,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "helpers.fullname" . }}-secret
                   key: "redis-password"
-          ports:
-            - containerPort: 6379
-          resources:
-            limits:
-              cpu: "1"
           livenessProbe:
             exec:
               command:
@@ -43,9 +39,26 @@ spec:
                 - "redis-cli -h $(hostname) incr health:counter"
             initialDelaySeconds: 15
             periodSeconds: 30
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              cpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: redis-data
               mountPath: "/data"
+      securityContext:
+        fsGroup: 999
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
       volumes:
         - name: redis-data
           {{- if .Values.redis_claim }}

--- a/charts/gafaelfawr/templates/redis-networkpolicy.yaml
+++ b/charts/gafaelfawr/templates/redis-networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "helpers.fullname" . }}-redis-networkpolicy
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "helpers.fullname" . }}-redis
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ template "helpers.fullname" . }}
+      ports:
+        - protocol: TCP
+          port: 6379


### PR DESCRIPTION
Add hardening configuration to the Gafaelfawr main deployment and
Redis deployment:

- Specify runAsUser, runAsGroup, and runAsNonRoot
- Disable Kubernetes service account tokens
- Disable privilege escalation
- Disable all capabilities
- Enable read-only file systems
- For Redis, specify an fsGroup and fsGroupChangePolicy

Also add a NetworkPolicy for the Redis deployment that only allows
incoming connections from the Gafaelfawr pod and no outbound
connections.

Rename redis-deployment to end in .yaml rather than .yml for
consistency.