### PR TITLE
[DM-25487] Add TLS configuration to nubaldo ingress

### DIFF
--- a/charts/nublado/Chart.yaml
+++ b/charts/nublado/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/lsst-sqre/nublado
 maintainers:
   - name: athornton
 name: nublado
-version: 0.9.7
+version: 0.9.8

--- a/charts/nublado/templates/jupyterhubproxy/ingress.template.yml
+++ b/charts/nublado/templates/jupyterhubproxy/ingress.template.yml
@@ -7,10 +7,19 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "0m"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/rewrite-target: {{ .Values.routes.hub }}/$2
+{{- if .Values.proxy.ingress.tls.cluster_issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.proxy.ingress.tls.cluster_issuer }}
+{{- end }}
 {{ if .Values.proxy.ingress.annotations }}
 {{ toYaml .Values.proxy.ingress.annotations | indent 4 }}
 {{ end }}
 spec:
+{{- if and .Values.proxy.ingress.tls.secret_name .Values.proxy.ingress.host }}
+  tls:
+    - secretName: {{ .Values.proxy.ingress.tls.secret_name }}
+      hosts:
+        - {{ .Values.proxy.ingress.host }}
+{{- end }}
   rules:
 {{ if .Values.proxy.ingress.host }}
   - host: {{ .Values.proxy.ingress.host }}

--- a/charts/nublado/templates/jupyterhubproxy/ingress.template.yml
+++ b/charts/nublado/templates/jupyterhubproxy/ingress.template.yml
@@ -14,11 +14,11 @@ metadata:
 {{ toYaml .Values.proxy.ingress.annotations | indent 4 }}
 {{ end }}
 spec:
-{{- if and .Values.proxy.ingress.tls.secret_name .Values.proxy.ingress.host }}
+{{- if and .Values.proxy.ingress.tls.secret_name .Values.proxy.ingress.tls.tls_host }}
   tls:
     - secretName: {{ .Values.proxy.ingress.tls.secret_name }}
       hosts:
-        - {{ .Values.proxy.ingress.host }}
+        - {{ .Values.proxy.ingress.tls.tls_host }}
 {{- end }}
   rules:
 {{ if .Values.proxy.ingress.host }}

--- a/charts/nublado/values.yaml
+++ b/charts/nublado/values.yaml
@@ -97,7 +97,9 @@ proxy:
   max_http_header_size: 16384
   ingress:
     host: ''
-    annotations: []
+    tls:
+      issuer: ''
+      secret_name: ''
 
 wf:
   image: 'lsstsqre/wfdispatcher:latest'

--- a/charts/nublado/values.yaml
+++ b/charts/nublado/values.yaml
@@ -100,6 +100,7 @@ proxy:
     tls:
       issuer: ''
       secret_name: ''
+      tls_host: ''
 
 wf:
   image: 'lsstsqre/wfdispatcher:latest'


### PR DESCRIPTION
For the base and summit clusters, we're not going to run the ingress
or the cert-manager installation.  Those instead will be handled by
IT.  However, the default cluster issuer will be configured for
lsst.org, rather than for our lsst.codes hostnames.

Add support to the nublado chart for configuring TLS for the hostname
used by the JuptyerHub proxy ingress.  ingress-nginx should then
merge that TLS configuration with all other ingress configurations
for the same hostname that don't specify a TLS configuration, which
is all of them at present.  That should accomplish the goal of using a
separate certificate issuer for the nublado hostname.  That issuer
will be set up by lsp-deploy.

Take the issuer name and the secret name as configuration settings in
values.yaml.