### PR TITLE
[DM-26412] Fix Gafaelfawr NetworkPolicy pod selector

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.4.5
+version: 1.4.6
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/redis-networkpolicy.yaml
+++ b/charts/gafaelfawr/templates/redis-networkpolicy.yaml
@@ -13,7 +13,7 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app: {{ template "helpers.fullname" . }}
+              name: {{ template "helpers.fullname" . }}
       ports:
         - protocol: TCP
           port: 6379


### PR DESCRIPTION
The app tag was set on the deployment but not the pod.  Select by
name instead of app.