### PR TITLE
[DM-25487] Fix values naming for nublado TLS configuration

### DIFF
--- a/charts/nublado/Chart.yaml
+++ b/charts/nublado/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/lsst-sqre/nublado
 maintainers:
   - name: athornton
 name: nublado
-version: 0.9.8
+version: 0.9.9

--- a/charts/nublado/templates/jupyterhubproxy/ingress.template.yml
+++ b/charts/nublado/templates/jupyterhubproxy/ingress.template.yml
@@ -14,9 +14,9 @@ metadata:
 {{ toYaml .Values.proxy.ingress.annotations | indent 4 }}
 {{ end }}
 spec:
-{{- if and .Values.proxy.ingress.tls.secret_name .Values.proxy.ingress.tls.tls_host }}
+{{- if and .Values.proxy.ingress.tls.secret .Values.proxy.ingress.tls.tls_host }}
   tls:
-    - secretName: {{ .Values.proxy.ingress.tls.secret_name }}
+    - secretName: {{ .Values.proxy.ingress.tls.secret }}
       hosts:
         - {{ .Values.proxy.ingress.tls.tls_host }}
 {{- end }}

--- a/charts/nublado/values.yaml
+++ b/charts/nublado/values.yaml
@@ -98,8 +98,8 @@ proxy:
   ingress:
     host: ''
     tls:
-      issuer: ''
-      secret_name: ''
+      cluster_issuer: ''
+      secret: ''
       tls_host: ''
 
 wf:


### PR DESCRIPTION
Use cluster_issuer, not issuer, and secret, not secret_name,
consistently in values.yaml and in the template.