### PR TITLE
[DM-26682] Add Gafaelfawr option to set InfluxDB username

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.4.7
+version: 1.4.8
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -27,6 +27,9 @@ data:
       exp_minutes: {{ .Values.issuer.exp_minutes }}
       {{- if .Values.issuer.influxdb.enabled }}
       influxdb_secret_file: "/etc/gafaelfawr/secrets/influxdb-secret"
+      {{- if .Values.issuer.influxdb.username }}
+      influxdb_username: {{ .Values.issuer.influxdb.username | quote }}
+      {{- end }}
       {{- end }}
 
     {{- if .Values.github }}

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -41,9 +41,12 @@ issuer:
   exp_minutes: 1440  # 1 day
 
   # Whether to issue tokens for InfluxDB.  If set to true, influxdb-secret
-  # must be set in the Gafaelfawr secret.
+  # must be set in the Gafaelfawr secret.  If username is also set, force
+  # all InfluxDB tokens to have that username instead of the authenticated
+  # identity of the user requesting a token.
   influxdb:
     enabled: false
+    username: ""
 
 # Whether to support OpenID Connect clients.  If set to true,
 # oidc-server-secrets must be set in the Gafaelfawr secret.


### PR DESCRIPTION
Add an option to the Gafaelfawr Helm chart to force the InfluxDB
username to a specific value.