### PR TITLE
[DM-26682] Bump Gafaelfawr version to 1.5.0

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.4.8
+version: 1.5.0
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:
   - name: rra
-appVersion: 1.4.1
+appVersion: 1.5.0

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -11,7 +11,7 @@ ingress:
 # Docker image to use.
 image:
   repository: "lsstsqre/gafaelfawr"
-  tag: "1.4.1"
+  tag: "1.5.0"
   pullPolicy: "IfNotPresent"
 
 # Existing PVC for redis claim


### PR DESCRIPTION
Pick up the new Gafaelfawr release and bump the chart version
accordingly.