### PR TITLE
[DM-26602] Add openid-configuration endpoint to Gafaelfawr

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.5.0
+version: 1.5.1
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -33,3 +33,9 @@ spec:
         backend:
           serviceName: {{ template "helpers.fullname" . }}-service
           servicePort: 8080
+      {{- if .Values.oidc_server.enabled }}
+      - path: /.well-known/openid-configuration
+        backend:
+          serviceName: {{ template "helpers.fullname" . }}-service
+          servicePort: 8080
+      {{- end }}


### PR DESCRIPTION
Gafaelfawr now supports exposing configuration information for its
OpenID Connect provider.  Conditionally add that to the ingress if
the OpenID Connect provider is enabled.