### PR TITLE
[DM-27044] Nublado2 chart initial commit

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: nublado2
+version: 0.0.1
+appVersion: 1.1.0
+description: Nublado2 JupyterHub installation
+home: https://github.com/lsst-sqre/nublado2
+maintainers:
+  - name: cbanek
+sources:
+  - https://github.com/lsst-sqre/nublado2
+  - https://github.com/lsst-sqre/charts
+kubeVersion: '>=1.11.0-0'

--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 sources:
   - https://github.com/lsst-sqre/nublado2
   - https://github.com/lsst-sqre/charts
-kubeVersion: '>=1.11.0-0'
+kubeVersion: '>=1.16.0-0'

--- a/charts/nublado2/requirements.yaml
+++ b/charts/nublado2/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: jupyterhub
+  version: "0.9.0-n409.hce116620"
+  repository: https://jupyterhub.github.io/helm-chart/

--- a/charts/nublado2/templates/_helpers.tpl
+++ b/charts/nublado2/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nublado2.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nublado2.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nublado2.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nublado2.labels" -}}
+app.kubernetes.io/name: {{ include "nublado2.name" . }}
+helm.sh/chart: {{ include "nublado2.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nublado2.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "nublado2.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/nublado2/templates/nublado-config.yaml
+++ b/charts/nublado2/templates/nublado-config.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nublado-config
+  labels:
+    {{- include "nublado2.labels" . | nindent 4 }}
+data:
+  hub_config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -1,0 +1,26 @@
+# Default values for nublado2.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+jupyterhub:
+  hub:
+    containerSecurityContext:
+      runAsUser: 768
+      runAsGroup: 768
+      fsGroup: 768
+      allowPrivilegeEscalation: false
+    baseUrl: '/n2'
+    extraConfig:
+      nublado.py: |
+        import nublado2.config
+        nublado2.config.setup_config(c)
+    extraVolumes:
+      - name: nublado-config
+        configMap:
+          name: nublado-config
+    extraVolumeMounts:
+      - name: nublado-config
+        mountPath: /etc/jupyterhub/hub_config.yaml
+        subPath: hub_config.yaml
+
+config: {}


### PR DESCRIPTION
Okay, so now we're basing a nublado2 initial chart on top of the
zero-to-jupyterhub chart as a subchart.  I'm not overriding the
jupyterhub_config.py, which means we're setting a couple other
things, and probably some I don't know or understand, but we'll
cross that bridge when we come to it.  This at least gets things
going, and the values.yaml configures the subchart with proper
UID/GID and the python that loads in the nublado2 library to
set up additional config.

I know the requirement is a bit janky, but this build contains
specific security configuration improvements to allow us to
just put the uid / gid yaml in directly.  We can update this as we
go, but we should test each update carefully since it is also
a code / functionality update.