### PR TITLE
[DM-27245] Nublado2 clusterrole

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nublado2
-version: 0.0.3
+version: 0.0.4
 appVersion: 1.1.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/templates/clusterrole.yml
+++ b/charts/nublado2/templates/clusterrole.yml
@@ -1,0 +1,23 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado2.fullname" . }}-hub
+rules:
+rules:
+- apiGroups: [""]
+  resources: ["pods","events", "namespaces", "serviceaccounts", "services",
+  "persistentvolumeclaims", "persistentvolumes", "resourcequotas",
+  "configmaps", "pods/log", "pods/exec"]
+  verbs: ["get", "list", "create", "watch", "delete", "update", "patch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "delete"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list", "create", "delete"]
+- apiGroups: ["argoproj.io"]
+  resources: ["workflows", "workflows/finalizers"]
+  verbs: ["get", "list", "create", "watch", "delete", "update", "patch"]
+- apiGroups: ["argoproj.io"]
+  resources: ["workflowtemplates", "workflowtemplates/finalizers"]
+  verbs: ["get", "list", "watch"]

--- a/charts/nublado2/templates/clusterrolebinding.yml
+++ b/charts/nublado2/templates/clusterrolebinding.yml
@@ -1,0 +1,13 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado2.fullname" . }}-hub
+subjects:
+  # Note: this service account is created by the jupyterhub subchart
+  - kind: ServiceAccount
+    name: hub
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "nublado2.fullname" . }}-hub
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This gives the hub role a lot more things it can do.  We need to be
able to use a clusterrole to create namespaces and watch pods in
other namespaces, so we'll need this for the multinamespace work.

This is also required to create any kubernetes objects from the
hub, so the arbitrary resource creation objects have to be of
types that can be created by the hub, otherwise you get a 403.

The list of roles comes from what is currently on nublado, so we
can trim it down, or keep it here and trim it once we get other
parts working.

Note that the clusterrolebinding binds to the service account that
the subchart creates.