### PR TITLE
[DM-27278] Add Gafaelfawr authenticator to nublado2

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nublado2
-version: 0.0.2
+version: 0.0.3
 appVersion: 1.1.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -26,6 +26,8 @@ jupyterhub:
     type: custom
     custom:
       className: nublado2.auth.GafaelfawrAuthenticator
+    state:
+      enabled: true
 
   # Any instantiation of this chart must also set ingress.hosts and add
   # the nginx.ingress.kubernetes.io/auth-signin and

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -7,7 +7,6 @@ jupyterhub:
     containerSecurityContext:
       runAsUser: 768
       runAsGroup: 768
-      fsGroup: 768
       allowPrivilegeEscalation: false
     baseUrl: '/n2'
     extraConfig:

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -29,6 +29,26 @@ jupyterhub:
     state:
       enabled: true
 
+  # This is specific to the outdated 0.9.0-n409.hce116620 version of the
+  # chart.  When we upgrade to the current version, change this setting
+  # to:
+  #
+  # proxy:
+  #   chp:
+  #     networkPolicy:
+  #       interNamespaceAccessLabels: accept
+  proxy:
+    networkPolicy:
+      ingress:
+        - ports:
+            - port: http
+          from:
+            - podSelector:
+                matchLabels:
+                  hub.jupyter.org/network-access-proxy-http: "true"
+              namespaceSelector:
+                matchLabels: {}
+
   # Any instantiation of this chart must also set ingress.hosts and add
   # the nginx.ingress.kubernetes.io/auth-signin and
   # nginx.ingress.kubernetes.io/auth-url headers pointing to the

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -28,4 +28,18 @@ jupyterhub:
     custom:
       className: nublado2.auth.GafaelfawrAuthenticator
 
+  # Any instantiation of this chart must also set ingress.hosts and add
+  # the nginx.ingress.kubernetes.io/auth-signin and
+  # nginx.ingress.kubernetes.io/auth-url headers pointing to the
+  # appropriate fully-qualified URLs for the Gafaelfawr /login and /auth
+  # routes.
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/auth-method: GET
+      nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Groups,X-Auth-Request-Uid,X-Auth-Request-Token"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        error_page 403 = "/auth/forbidden?scope=exec:notebook";
+
 config: {}

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -23,4 +23,9 @@ jupyterhub:
         mountPath: /etc/jupyterhub/nublado_config.yaml
         subPath: nublado_config.yaml
 
+  auth:
+    type: custom
+    custom:
+      className: nublado2.auth.GafaelfawrAuthenticator
+
 config: {}


### PR DESCRIPTION
- Configure the new Gafaelfawr authenticator for nublado2
- Remove the `fsGroup` setting since it requires Kubernetes 1.19
- Add ingress configuration for nublado2 (except for the parts that are environment-specific)
- Enable authentication state storage for nublado2 (used by Gafaelfawr)
- Add a NetworkPolicy to allow the nginx ingress to talk to the JupyterHub proxy