### PR TITLE
[DM-27441] Nublado2: turn off prepuller

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nublado2
-version: 0.0.6
+version: 0.0.7
 appVersion: 1.1.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -26,6 +26,12 @@ jupyterhub:
         mountPath: /etc/jupyterhub/nublado_config.yaml
         subPath: nublado_config.yaml
 
+  prePuller:
+    continuous:
+      enabled: false
+    hook:
+      enabled: false
+
   singleuser:
     defaultUrl: "/lab"
 


### PR DESCRIPTION
Turn off the prepuller in the helm chart.  It doesn't seem to work
in argocd, but it does work on the helm command line...  We don't
use it anyway, so disable it.