### PR TITLE
[DM-28227] Fix Gafaelfawr auth-url annotation for tokens

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.5.4
+version: 1.5.5
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/ingress-token.yaml
+++ b/charts/gafaelfawr/templates/ingress-token.yaml
@@ -6,7 +6,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-request-redirect: $request_uri
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
     nginx.ingress.kubernetes.io/auth-signin: https://{{ .Values.host }}/login
-    nginx.ingress.kubernetes.io/auth-url: http://gafaelfawr-service.{{ .Release.Namespace }}:8080/auth?scope={{ .Values.user_scope }}
+    nginx.ingress.kubernetes.io/auth-url: http://gafaelfawr-service.{{ .Release.Namespace }}.svc.cluster.local:8080/auth?scope={{ .Values.user_scope }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       error_page 403 = "/auth/forbidden?scope={{ .Values.user_scope }}";
   name: {{ template "helpers.fullname" . }}-token-ingress


### PR DESCRIPTION
Using an unqualified gafaelfawr-service.gafaelfawr doesn't work
because nginx uses a Lua DNS library that doesn't honor the search
option in /etc/resolv.conf.

We had previously not used svc.cluster.local because of some issue
on the summit, but inspecting the summit DNS configuration now, it
appears to use cluster.local as its default domain and thus
svc.cluster.local should work.  Return to that configuration,
which will hopefully work on all of our environments.

This problem is temporary since Gafaelfawr 2.0.0 will remove the
need for this annotation in the Gafaelfawr chart (although we'll
still need something similar in the charts of other protected
services).