### PR TITLE
[DM-28478] Update neophile to 0.2.0, add security config

### DIFF
--- a/charts/neophile/Chart.yaml
+++ b/charts/neophile/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 name: neophile
-version: 0.1.1
+version: 0.2.0
 description: Periodically check for needed dependency updates
 home: https://neophile.lsst.io/
 maintainers:
   - name: rra
-appVersion: 0.1.0
+appVersion: 0.2.0

--- a/charts/neophile/templates/cronjob.yaml
+++ b/charts/neophile/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
 {{ include "helpers.labels" . | indent 12 }}
         spec:
           restartPolicy: "Never"
+          automountServiceAccountToken: false
           containers:
             - name: {{ template "helpers.fullname" . }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -28,12 +29,21 @@ spec:
                     secretKeyRef:
                       name: {{ template "helpers.fullname" . }}-secret
                       key: "github_token"
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - all
               volumeMounts:
                 - name: {{ template "helpers.fullname" . }}-config
                   mountPath: "/etc/neophile"
                   readOnly: true
                 - name: {{ template "helpers.fullname" . }}-data
                   mountPath: "/data"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
           volumes:
             - name: {{ template "helpers.fullname" . }}-config
               configMap:

--- a/charts/neophile/values.yaml
+++ b/charts/neophile/values.yaml
@@ -11,7 +11,7 @@ repositories: {}
 # Docker image to use.
 image:
   repository: "lsstsqre/neophile"
-  tag: "0.1.0"
+  tag: "0.2.0"
   pullPolicy: "IfNotPresent"
 
 # Execution schedule (default is 4am on Monday).


### PR DESCRIPTION
Update to 0.2.0 as the default image.  Add a securityContext
configuration to the container and job to drop permissions and
run as non-root.  Disable automount of the Kubernetes service
account token.