### PR TITLE
[DM-28482] Nublado2: default empty image list

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nublado2
-version: 0.0.8
+version: 0.0.9
 appVersion: 1.1.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -80,6 +80,7 @@ jupyterhub:
 
 config:
   options_form:
+    images: []
     images_url: "http://cachemachine.cachemachine/cachemachine/jupyter/available"
     sizes:
       - name: Tiny


### PR DESCRIPTION
Add in an empty list for the other images to show.  Otherwise
nublado2 will get unhappy when showing the options form and trying
to find the default list of images to show.  By default, there is
nothing in there.  But someone could use this list instead of
cachemachine, or merge it with those results.