### PR TITLE
[DM-28666] Update Nublado 2 auth configuration

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nublado2
-version: 0.0.9
+version: 0.0.10
 appVersion: 1.1.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -65,20 +65,24 @@ jupyterhub:
                 matchLabels: {}
 
   # Any instantiation of this chart must also set ingress.hosts and add
-  # the nginx.ingress.kubernetes.io/auth-signin and
-  # nginx.ingress.kubernetes.io/auth-url headers pointing to the
-  # appropriate fully-qualified URLs for the Gafaelfawr /login and /auth
-  # routes.
+  # the nginx.ingress.kubernetes.io/auth-signin annotation pointing to the
+  # appropriate fully-qualified URLs for the Gafaelfawr /login route.
   ingress:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/auth-method: GET
-      nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Groups,X-Auth-Request-Uid,X-Auth-Request-Token"
+      nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
+      nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         error_page 403 = "/auth/forbidden?scope=exec:notebook";
 
 config:
+  # base_url must be set in each instantiation of this chart to the URL of
+  # the primary ingress.  It's used to construct API requests to the
+  # authentication service (which should go through the ingress).
+  base_url: ""
+
   options_form:
     images: []
     images_url: "http://cachemachine.cachemachine/cachemachine/jupyter/available"


### PR DESCRIPTION
We can now use the same auth-url on all environments, so set it to
the gafaelfawr-service.gafaelfawr.svc.cluster.local URL so that
instantiations don't have to set it.  Pass only the token into
Nublado 2, not other headers, since we'll use an API call to retrieve
the other data.  Add a base_url config setting that has to be
set on all instantiations, which will be used to construct the URL
to contact Gafaelfawr and retrieve token metadata.