### PR TITLE
[DM-28686] Security hardening for cachemachine chart

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 name: cachemachine
 maintainers:
   - name: cbanek
-version: 0.1.1
+version: 0.1.2

--- a/charts/cachemachine/templates/pull-networkpolicy.yaml
+++ b/charts/cachemachine/templates/pull-networkpolicy.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "helpers.fullname" . }}-pull-networkpolicy
+spec:
+  podSelector:
+    matchLabels:
+      cachemachine: pull
+  policyTypes:
+    - Ingress
+    - Egress

--- a/charts/cachemachine/values.yaml
+++ b/charts/cachemachine/values.yaml
@@ -19,16 +19,17 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
 
 service:
   type: ClusterIP
@@ -36,9 +37,9 @@ service:
 
 ingress:
   enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  annotations:
+    nginx.ingress.kubernetes.io/auth-method: GET
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:admin"
   hosts:
     - host: chart-example.local
       paths: ["/cachemachine"]


### PR DESCRIPTION
Put the external ingress for cachemachine behind Gafaelfawr to
prevent the Internet from talking to it without authentication.
We will eventually also want to restrict access to it from inside
the cluster, but that's much less important and can be tackled via
a NetworkPolicy later.

Add pod and container hardening best practices from SQR-048, which
should be a no-op for this service since it doesn't do anything
exciting other than answer HTTP requests and make Kubernetes API
calls.

Add a NetworkPolicy that will be used by spawned pods to deny all
network traffic.