### PR TITLE
[DM-28686] Fix helpers -> cachemachine

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 name: cachemachine
 maintainers:
   - name: cbanek
-version: 0.1.2
+version: 0.1.3

--- a/charts/cachemachine/templates/pull-networkpolicy.yaml
+++ b/charts/cachemachine/templates/pull-networkpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ template "helpers.fullname" . }}-pull-networkpolicy
+  name: {{ template "cachemachine.fullname" . }}-pull-networkpolicy
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
This broke in applying the chart in the minikube deployment in
lsp-deploy, this should be cachemachine I think.