### PR TITLE
[DM-28726] Cachemachine: autostart configmap

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 name: cachemachine
 maintainers:
   - name: cbanek
-version: 0.1.3
+version: 0.1.4

--- a/charts/cachemachine/templates/configmap.yaml
+++ b/charts/cachemachine/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cachemachine.fullname" . }}-autostart
+  labels:
+{{ include "cachemachine.labels" . | indent 4 }}
+data:
+  {{- toYaml .Values.autostart | nindent 2 }}

--- a/charts/cachemachine/templates/deployment.yaml
+++ b/charts/cachemachine/templates/deployment.yaml
@@ -48,16 +48,24 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if .Values.docker_secret_name }}
           volumeMounts:
+          {{- if .Values.docker_secret_name }}
           - name: docker-creds
             mountPath: "/etc/secrets"
             readOnly: true
+          {{- end }}
+          - name: autostart
+            mountPath: "/etc/cachemachine"
+            readOnly: true
       volumes:
+      {{- if .Values.docker_secret_name }}
       - name: docker-creds
         secret:
           secretName: {{ .Values.docker_secret_name }}
       {{- end }}
+      - name: autostart
+        configMap:
+          name: {{ include "cachemachine.fullname" . }}-autostart
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cachemachine/values.yaml
+++ b/charts/cachemachine/values.yaml
@@ -73,3 +73,5 @@ vault_secrets:
   name: "docker-creds"
   enabled: false
   path: ""
+
+autostart: {}


### PR DESCRIPTION
Add the configmap that contains JSON files to create preconfigured
cachemachines at startup.