### PR TITLE
[DM-28725] Nublado2 network policy

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nublado2
-version: 0.0.12
+version: 0.0.13
 appVersion: 1.1.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/templates/netpol.yaml
+++ b/charts/nublado2/templates/netpol.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.network_policy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hub
+  labels:
+    {{- include "nublado2.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: jupyterhub
+      component: hub
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # allowed pods (hub.jupyter.org/network-access-hub) --> hub
+    - ports:
+        - port: http
+      from:
+        - podSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-hub: "true"
+          namespaceSelector: {}
+
+  egress:
+    # hub --> proxy
+    - ports:
+        - port: 8001
+      to:
+        - podSelector:
+            matchLabels:
+              app: jupyterhub
+              component: proxy
+              release: {{ .Release.Name }}
+
+    # hub --> singleuser-server
+    - ports:
+        - port: 8888
+      to:
+        - podSelector:
+            matchLabels:
+              app: jupyterhub
+              component: singleuser-server
+              release: {{ .Release.Name }}
+          namespaceSelector: {}
+
+    # hub -> Kubernetes internal DNS
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -25,6 +25,10 @@ jupyterhub:
       - name: nublado-config
         mountPath: /etc/jupyterhub/nublado_config.yaml
         subPath: nublado_config.yaml
+    networkPolicy:
+      # This is set to disabled but is basically re-implemented by
+      # the netpol.yaml in this chart.
+      enabled: false
 
   prePuller:
     continuous:
@@ -119,3 +123,6 @@ vault_secret_path: ""
 
 # Pull secret:
 pull_secret: ""
+
+network_policy:
+  enabled: true


### PR DESCRIPTION
Since the hub and the single user lab pods are running in different
namespaces, we need to modify the hub's network policy in a way
that can't be configured currently.  So just wrap it up into the
nublado2 chart.