### PR TITLE
[DM-28845] Support the test CILogon instance in Gafaelfawr

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.5.5
+version: 1.5.6
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -43,7 +43,15 @@ data:
     oidc:
       client_id: {{ .Values.cilogon.client_id | quote }}
       client_secret_file: "/etc/gafaelfawr/secrets/cilogon-client-secret"
+      {{- if .Values.cilogon.test }}
+      login_url: "https://test.cilogon.org/authorize"
+      token_url: "https://test.cilogon.org/oauth2/token"
+      issuer: "https://test.cilogon.org"
+      {{- else }}
       login_url: "https://cilogon.org/authorize"
+      token_url: "https://cilogon.org/oauth2/token"
+      issuer: "https://cilogon.org"
+      {{- end }}
       {{- if .Values.cilogon.login_params }}
       login_params:
         {{- range $key, $value := .Values.cilogon.login_params }}
@@ -55,11 +63,9 @@ data:
       {{- else }}
       redirect_url: "https://{{ .Values.host }}/login"
       {{- end }}
-      token_url: "https://cilogon.org/oauth2/token"
       scopes:
         - "email"
         - "org.cilogon.userinfo"
-      issuer: "https://cilogon.org"
       audience: {{ .Values.cilogon.client_id | quote }}
       key_ids:
         - "244B235F6B28E34108D101EAC7362C4E"

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -39,6 +39,24 @@ proxies:
   - "172.16.0.0/12"
   - "192.168.0.0/16"
 
+# Example configuration for using CILogon.
+# cilogon:
+#   client_id: "cilogon:/client_id/<some-id>"
+#
+#   # If the registered URL is different from /login (the default).
+#   redirect_url: "https://<hostname>/oauth2/callback"
+#
+#   # Whether to use the test instance.
+#   test: false
+#
+#   # Additional parameters to add.
+#   login_params:
+#     skin: "LSST"
+
+# Example configuration for using GitHub.
+# github:
+#   client_id: "<github-client-id>"
+
 issuer:
   # Session length and token expiration (in minutes).
   exp_minutes: 1440  # 1 day


### PR DESCRIPTION
Allow setting cilogon.test to true in the Gafaelfawr chart to use
the test instance instead of the primary instance.  Add examples of
CILogon and GitHub configuration.