### PR TITLE
[DM-28923] Nublado2: get rid of egress policy

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nublado2
-version: 0.0.13
+version: 0.0.14
 appVersion: 1.1.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/templates/netpol.yaml
+++ b/charts/nublado2/templates/netpol.yaml
@@ -13,7 +13,6 @@ spec:
       release: {{ .Release.Name }}
   policyTypes:
     - Ingress
-    - Egress
 
   ingress:
     # allowed pods (hub.jupyter.org/network-access-hub) --> hub
@@ -24,33 +23,4 @@ spec:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
           namespaceSelector: {}
-
-  egress:
-    # hub --> proxy
-    - ports:
-        - port: 8001
-      to:
-        - podSelector:
-            matchLabels:
-              app: jupyterhub
-              component: proxy
-              release: {{ .Release.Name }}
-
-    # hub --> singleuser-server
-    - ports:
-        - port: 8888
-      to:
-        - podSelector:
-            matchLabels:
-              app: jupyterhub
-              component: singleuser-server
-              release: {{ .Release.Name }}
-          namespaceSelector: {}
-
-    # hub -> Kubernetes internal DNS
-    - ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
 {{- end }}


### PR DESCRIPTION
We're more worried about ingress than egress.  For now let's
disable egress.  This allows the hub to contact everyone on the
internet.