### PR TITLE
[DM-28993] Bump neophile version, add more hardening

### DIFF
--- a/charts/neophile/Chart.yaml
+++ b/charts/neophile/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: neophile
-version: 0.2.0
+version: 0.2.1
 description: Periodically check for needed dependency updates
 home: https://neophile.lsst.io/
 maintainers:
   - name: rra
-appVersion: 0.2.0
+appVersion: 0.2.1

--- a/charts/neophile/templates/cronjob.yaml
+++ b/charts/neophile/templates/cronjob.yaml
@@ -34,6 +34,7 @@ spec:
                 capabilities:
                   drop:
                     - all
+                readOnlyRootFilesystem: true
               volumeMounts:
                 - name: {{ template "helpers.fullname" . }}-config
                   mountPath: "/etc/neophile"


### PR DESCRIPTION
Bump the version of neophile to 0.2.1 and mark the root file system
of the cron job container as read-only.