### PR TITLE
[DM-28993] Set version of cachemachine Docker image

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -4,4 +4,5 @@ description: A Helm chart for Kubernetes
 name: cachemachine
 maintainers:
   - name: cbanek
-version: 0.1.4
+version: 0.1.5
+appVersion: 1.0.5

--- a/charts/cachemachine/values.yaml
+++ b/charts/cachemachine/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: lsstsqre/cachemachine
-  tag: latest
+  tag: 1.0.5
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Our GitHub Actions machinery doesn't set the latest tag, so using
that in the deployment doesn't work well.  Pin to the latest version
and reflect that in the appVersion field of Chart.yaml.