### PR TITLE
Fix CI configuration for helm/chart-testing-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
       - name: Run chart-testing (lint)
         id: lint
         uses: helm/chart-testing-action@v2.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Run chart-testing (lint)
-        id: lint
+      - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1
-        with:
-          command: lint
+
+      - name: Run chart-testing (lint)
+        run: ct lint


### PR DESCRIPTION
- Install Python 3.8
- Change the way the lint action is kicked off