### PR TITLE
[DM-29329] Fix syntax of required function

### DIFF
--- a/charts/neophile/Chart.yaml
+++ b/charts/neophile/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: neophile
-version: 0.2.3
+version: 0.2.4
 description: Periodically check for needed dependency updates
 home: https://neophile.lsst.io/
 maintainers:

--- a/charts/neophile/templates/configmap.yaml
+++ b/charts/neophile/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- required "config.githubUser is required" .Values.config.githubUser -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,7 +11,7 @@ data:
     {{- if .Values.config.githubEmail }}
     github_email: {{ .Values.config.githubEmail | quote }}
     {{- end }}
-    github_user: {{ .Values.config.githubUser | quote }}
+    github_user: {{- required "config.githubUser is required" .Values.config.githubUser | quote -}}
     repositories:
       {{- range $repository := .Values.config.repositories }}
       - owner: {{ $repository.owner }}


### PR DESCRIPTION
This returns the value that is marked as required, so it's supposed
to be used in a pipeline where that value is used, not at the top
of the chart.