### PR TITLE
[DM-29329] Fix whitespace bug in the neophile chart

### DIFF
--- a/charts/neophile/Chart.yaml
+++ b/charts/neophile/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: neophile
-version: 0.2.4
+version: 0.2.5
 description: Periodically check for needed dependency updates
 home: https://neophile.lsst.io/
 maintainers:

--- a/charts/neophile/templates/configmap.yaml
+++ b/charts/neophile/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
     {{- if .Values.config.githubEmail }}
     github_email: {{ .Values.config.githubEmail | quote }}
     {{- end }}
-    github_user: {{- required "config.githubUser is required" .Values.config.githubUser | quote -}}
+    github_user: {{ required "config.githubUser is required" .Values.config.githubUser | quote }}
     repositories:
       {{- range $repository := .Values.config.repositories }}
       - owner: {{ $repository.owner }}


### PR DESCRIPTION
Fix bug introduced in 0.2.4 when fixing the required function that
collapsed too much whitespace.