### PR TITLE
Remove pod_uid, force NO_SUDO in lab environment

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nublado2
-version: 0.0.20
+version: 0.0.21
 appVersion: 1.0.1
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -103,7 +103,12 @@ config:
   # auth.
   # Sometimes, we start the pod as the provisioning user (uid 769) which has
   # the permission to sudo to do the work of changing to the user.
+  # This should be null if we are not using sudo.
   pod_uid: 769
+  # no_sudo is a string value; it is used in conjunction with pod_uid.
+  # If pod_uid is null the value should be "TRUE", otherwise it should
+  # be the empty string.
+  no_sudo: ""
   options_form:
     images: []
     images_url: "http://cachemachine.cachemachine/cachemachine/jupyter/available"
@@ -143,6 +148,7 @@ config:
         EXTERNAL_GROUPS: "{{ external_groups }}"
         EXTERNAL_UID: "{{ uid }}"
         ACCESS_TOKEN: "{{ token }}"
+        NO_SUDO: "{{ no_sudo }}"
     - apiVersion: v1
       kind: ConfigMap
       metadata:

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -98,17 +98,6 @@ config:
   base_url: ""
   signing_key_path: "/etc/keys/signing_key.pem"
 
-  # What uid should the pod be started as?  If it is set, use that uid for
-  # starting each pod.  If not set, use the uid provided from gafaelfawr in
-  # auth.
-  # Sometimes, we start the pod as the provisioning user (uid 769) which has
-  # the permission to sudo to do the work of changing to the user.
-  # This should be null if we are not using sudo.
-  pod_uid: 769
-  # no_sudo is a string value; it is used in conjunction with pod_uid.
-  # If pod_uid is null the value should be "TRUE", otherwise it should
-  # be the empty string.
-  no_sudo: ""
   options_form:
     images: []
     images_url: "http://cachemachine.cachemachine/cachemachine/jupyter/available"
@@ -148,7 +137,7 @@ config:
         EXTERNAL_GROUPS: "{{ external_groups }}"
         EXTERNAL_UID: "{{ uid }}"
         ACCESS_TOKEN: "{{ token }}"
-        NO_SUDO: "{{ no_sudo }}"
+        NO_SUDO: "TRUE"
     - apiVersion: v1
       kind: ConfigMap
       metadata:


### PR DESCRIPTION
Because the stuff in config.user_resources is a list, if you don't do no_sudo like this, it means a huge amount of duplication in the environment values file.