### PR TITLE
[DM-29329] Bump neophile version, mount home directory

### DIFF
--- a/charts/neophile/Chart.yaml
+++ b/charts/neophile/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: neophile
-version: 0.2.5
+version: 0.2.6
 description: Periodically check for needed dependency updates
 home: https://neophile.lsst.io/
 maintainers:
   - name: rra
-appVersion: 0.2.1
+appVersion: 0.2.2

--- a/charts/neophile/templates/cronjob.yaml
+++ b/charts/neophile/templates/cronjob.yaml
@@ -53,6 +53,8 @@ spec:
               volumeMounts:
                 - name: "tmp"
                   mountPath: "/tmp"
+                - name: "home"
+                  mountPath: "/home/appuser"
                 - name: "config"
                   mountPath: "/etc/neophile"
                   readOnly: true
@@ -60,6 +62,8 @@ spec:
                   mountPath: "/data"
           volumes:
             - name: "tmp"
+              emptyDir: {}
+            - name: "home"
               emptyDir: {}
             - name: "config"
               configMap:


### PR DESCRIPTION
Create a writable home directory for the neophile user since it's
used by pip.  Bump the appVersion to the new 0.2.2 release, which
has a fix for GitHub's main vs. master branch change.