### PR TITLE
[DM-29085] Overhaul Gafaelfawr Helm chart

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.5.6
+version: 1.5.7
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: gafaelfawr
-version: 1.5.7
+version: 2.0.0
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: gafaelfawr
 version: 2.0.0
 description: The Gafaelfawr authentication and authorization system

--- a/charts/gafaelfawr/ci/values-default.yaml
+++ b/charts/gafaelfawr/ci/values-default.yaml
@@ -1,0 +1,1 @@
+# Empty values file to lint with the defaults.

--- a/charts/gafaelfawr/ci/values-idfprod.yaml
+++ b/charts/gafaelfawr/ci/values-idfprod.yaml
@@ -1,0 +1,37 @@
+imagePullSecrets:
+  - "pull-secret"
+ingress:
+  host: "data.lsst.cloud"
+vaultSecretsPath: "secret/k8s_operator/data.lsst.cloud/gafaelfawr"
+
+# Use the CSI storage class so that we can use snapshots.
+redis:
+  persistence:
+    storageClass: "standard-rwo"
+
+config:
+  host: "data.lsst.cloud"
+
+  github:
+    clientId: "65b6333a066375091548"
+
+  # Allow access by GitHub team.
+  group_mapping:
+    "exec:admin":
+      - "lsst-sqre-square"
+    "exec:notebook":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-data-management"
+    "exec:portal":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-data-management"
+    "exec:user":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-data-management"
+    "read:tap":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-data-management"

--- a/charts/gafaelfawr/ci/values-stable.yaml
+++ b/charts/gafaelfawr/ci/values-stable.yaml
@@ -1,0 +1,33 @@
+imagePullSecrets:
+  - "pull-secret"
+ingress:
+  host: "lsst-lsp-stable.ncsa.illinois.edu"
+vaultSecretsPath: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/gafaelfawr"
+
+# Use an existing, manually-managed PVC for Redis.
+redis:
+  persistence:
+    volumeClaimName: "auth-redis-volume-claim"
+
+config:
+  host: "lsst-lsp-stable.ncsa.illinois.edu"
+
+  # IP range used by the cluster, used to determine the true client IP for
+  # logging.
+  proxies:
+    - "41.142.182.128/26"
+
+  # Use CILogon authentication.
+  cilogon:
+    clientId: "cilogon:/client_id/7ae419868b97e81644ced9886ffbcec"
+    redirectUrl: "https://lsst-lsp-stable.ncsa.illinois.edu/oauth2/callback"
+    loginParams:
+      skin: "LSST"
+
+  # Use NCSA groups to determine token scopes.
+  groupMapping:
+    "exec:admin": ["lsst_int_lsp_admin"]
+    "exec:notebook": ["lsst_int_lspdev"]
+    "exec:portal": ["lsst_int_lspdev"]
+    "exec:user": ["lsst_int_lspdev"]
+    "read:tap": ["lsst_int_lspdev"]

--- a/charts/gafaelfawr/ci/values-summit.yaml
+++ b/charts/gafaelfawr/ci/values-summit.yaml
@@ -1,0 +1,39 @@
+imagePullSecrets:
+  - "pull-secret"
+ingress:
+  host: "summit-lsp.lsst.codes"
+vaultSecretsPath: "secret/k8s_operator/summit-lsp.lsst.codes/gafaelfawr"
+
+# Reset token storage on every Redis restart for now.  This should change to
+# use persistent volumes once we can coordinate that.
+redis:
+  persistence:
+    enabled: false
+
+config:
+  host: "summit-lsp.lsst.codes"
+
+  # Use GitHub authentication.
+  github:
+    clientId: "220d64cbf46f9d2b7873"
+
+  # Allow access by GitHub team.
+  groupMapping:
+    "exec:admin":
+      - "lsst-sqre-square"
+    "exec:notebook":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-ts-summit-access"
+    "exec:portal":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-ts-summit-access"
+    "exec:user":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-ts-summit-access"
+    "read:tap":
+      - "lsst-sqre-square"
+      - "lsst-sqre-friends"
+      - "lsst-ts-summit-access"

--- a/charts/gafaelfawr/templates/_helpers.tpl
+++ b/charts/gafaelfawr/templates/_helpers.tpl
@@ -2,44 +2,51 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "helpers.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "gafaelfawr.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "helpers.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- define "gafaelfawr.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "helpers.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "gafaelfawr.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "helpers.labels" -}}
-app.kubernetes.io/name: {{ include "helpers.name" . }}
-helm.sh/chart: {{ include "helpers.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- define "gafaelfawr.labels" -}}
+helm.sh/chart: {{ include "gafaelfawr.chart" . }}
+{{ include "gafaelfawr.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gafaelfawr.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gafaelfawr.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -6,46 +6,46 @@ metadata:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 data:
   gafaelfawr.yaml: |
-    realm: {{ .Values.host | quote }}
-    loglevel: {{ .Values.loglevel | quote }}
+    realm: {{ required "config.host must be set" .Values.config.host | quote }}
+    loglevel: {{ .Values.config.loglevel | quote }}
     session_secret_file: "/etc/gafaelfawr/secrets/session-secret"
     redis_url: "redis://{{ template "gafaelfawr.fullname" . }}-redis-service.{{ .Release.Namespace }}:6379/0"
     redis_password_file: "/etc/gafaelfawr/secrets/redis-password"
-    {{- if .Values.proxies }}
+    {{- if .Values.config.proxies }}
     proxies:
-      {{- range $netblock := .Values.proxies }}
+      {{- range $netblock := .Values.config.proxies }}
       - {{ $netblock | quote }}
       {{- end }}
     {{- end }}
-    after_logout_url: "https://{{ .Values.host }}/"
+    after_logout_url: "https://{{ .Values.config.host }}/"
 
     issuer:
-      iss: "https://{{ .Values.host }}"
+      iss: "https://{{ .Values.config.host }}"
       key_id: "reissuer"
       aud:
-        default: "https://{{ .Values.host }}"
-        internal: "https://{{ .Values.host }}/api"
+        default: "https://{{ .Values.config.host }}"
+        internal: "https://{{ .Values.config.host }}/api"
       key_file: "/etc/gafaelfawr/secrets/signing-key"
-      exp_minutes: {{ .Values.issuer.exp_minutes }}
-      {{- if .Values.issuer.influxdb.enabled }}
+      exp_minutes: {{ .Values.config.issuer.expMinutes }}
+      {{- if .Values.config.issuer.influxdb.enabled }}
       influxdb_secret_file: "/etc/gafaelfawr/secrets/influxdb-secret"
-      {{- if .Values.issuer.influxdb.username }}
-      influxdb_username: {{ .Values.issuer.influxdb.username | quote }}
+      {{- if .Values.config.issuer.influxdb.username }}
+      influxdb_username: {{ .Values.config.issuer.influxdb.username | quote }}
       {{- end }}
       {{- end }}
 
-    {{- if .Values.github }}
+    {{- if .Values.config.github }}
 
     github:
-      client_id: {{ .Values.github.client_id | quote }}
+      client_id: {{ .Values.config.github.clientId | quote }}
       client_secret_file: "/etc/gafaelfawr/secrets/github-client-secret"
 
-    {{- else if .Values.cilogon }}
+    {{- else if .Values.config.cilogon }}
 
     oidc:
-      client_id: {{ .Values.cilogon.client_id | quote }}
+      client_id: {{ .Values.config.cilogon.clientId | quote }}
       client_secret_file: "/etc/gafaelfawr/secrets/cilogon-client-secret"
-      {{- if .Values.cilogon.test }}
+      {{- if .Values.config.cilogon.test }}
       login_url: "https://test.cilogon.org/authorize"
       token_url: "https://test.cilogon.org/oauth2/token"
       issuer: "https://test.cilogon.org"
@@ -54,37 +54,37 @@ data:
       token_url: "https://cilogon.org/oauth2/token"
       issuer: "https://cilogon.org"
       {{- end }}
-      {{- if .Values.cilogon.login_params }}
+      {{- if .Values.config.cilogon.loginParams }}
       login_params:
-        {{- range $key, $value := .Values.cilogon.login_params }}
+        {{- range $key, $value := .Values.config.cilogon.loginParams }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
-      {{- if .Values.cilogon.redirect_url }}
-      redirect_url: {{ .Values.cilogon.redirect_url | quote }}
+      {{- if .Values.config.cilogon.redirectUrl }}
+      redirect_url: {{ .Values.config.cilogon.redirectUrl | quote }}
       {{- else }}
       redirect_url: "https://{{ .Values.host }}/login"
       {{- end }}
       scopes:
         - "email"
         - "org.cilogon.userinfo"
-      audience: {{ .Values.cilogon.client_id | quote }}
+      audience: {{ .Values.config.cilogon.clientId | quote }}
       key_ids:
         - "244B235F6B28E34108D101EAC7362C4E"
 
     {{- end }}
 
-    {{- if .Values.oidc_server.enabled }}
+    {{- if .Values.config.oidcServer.enabled }}
     oidc_server_secrets_file: "/etc/gafaelfawr/secrets/oidc-server-secrets"
     {{- end }}
 
     known_scopes:
-      {{- range $key, $value := .Values.known_scopes }}
+      {{- range $key, $value := .Values.config.knownScopes }}
       {{ $key | quote }}: {{ $value | quote }}
       {{- end }}
 
     group_mapping:
-      {{- range $key, $value := .Values.group_mapping }}
+      {{- range $key, $value := .Values.config.groupMapping }}
       {{ $key | quote }}:
         {{- range $group := $value }}
         - {{ $group | quote }}

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -1,13 +1,15 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "helpers.fullname" . }}-configmap
+  name: {{ template "gafaelfawr.fullname" . }}-configmap
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 data:
   gafaelfawr.yaml: |
     realm: {{ .Values.host | quote }}
     loglevel: {{ .Values.loglevel | quote }}
     session_secret_file: "/etc/gafaelfawr/secrets/session-secret"
-    redis_url: "redis://{{ template "helpers.fullname" . }}-redis-service.{{ .Release.Namespace }}:6379/0"
+    redis_url: "redis://{{ template "gafaelfawr.fullname" . }}-redis-service.{{ .Release.Namespace }}:6379/0"
     redis_password_file: "/etc/gafaelfawr/secrets/redis-password"
     {{- if .Values.proxies }}
     proxies:

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-configmap
+  name: {{ template "gafaelfawr.fullname" . }}-config
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 data:
@@ -9,7 +9,7 @@ data:
     realm: {{ required "config.host must be set" .Values.config.host | quote }}
     loglevel: {{ .Values.config.loglevel | quote }}
     session_secret_file: "/etc/gafaelfawr/secrets/session-secret"
-    redis_url: "redis://{{ template "gafaelfawr.fullname" . }}-redis-service.{{ .Release.Namespace }}:6379/0"
+    redis_url: "redis://{{ template "gafaelfawr.fullname" . }}-redis.{{ .Release.Namespace }}:6379/0"
     redis_password_file: "/etc/gafaelfawr/secrets/redis-password"
     {{- if .Values.config.proxies }}
     proxies:

--- a/charts/gafaelfawr/templates/deployment.yaml
+++ b/charts/gafaelfawr/templates/deployment.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "helpers.fullname" . }}
+  name: {{ template "gafaelfawr.fullname" . }}
   labels:
-    app: {{ template "helpers.fullname" . }}
-{{ include "helpers.labels" . | indent 4 }}
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: {{ template "helpers.fullname" . }}
+      {{- include "gafaelfawr.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "frontend"
   template:
     metadata:
       labels:
-        name: {{ template "helpers.fullname" . }}
-{{ include "helpers.labels" . | indent 8 }}
+        {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "frontend"
     spec:
       automountServiceAccountToken: false
       containers:
@@ -23,32 +23,32 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           ports:
             - containerPort: 8080
-              name: app
+              name: "app"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - all
+                - "all"
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: {{ template "helpers.fullname" . }}-config
+            - name: {{ template "gafaelfawr.fullname" . }}-config
               mountPath: "/etc/gafaelfawr"
               readOnly: true
-            - name: {{ template "helpers.fullname" . }}-secret
+            - name: {{ template "gafaelfawr.fullname" . }}-secret
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
       {{- if .Values.pull_secret }}
       imagePullSecrets:
-      - name: {{ .Values.pull_secret }}
+        - name: {{ .Values.pull_secret }}
       {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
       volumes:
-        - name: {{ template "helpers.fullname" . }}-config
+        - name: {{ template "gafaelfawr.fullname" . }}-config
           configMap:
-            name: {{ template "helpers.fullname" . }}-configmap
-        - name: {{ template "helpers.fullname" . }}-secret
+            name: {{ template "gafaelfawr.fullname" . }}-configmap
+        - name: {{ template "gafaelfawr.fullname" . }}-secret
           secret:
-            secretName: {{ template "helpers.fullname" . }}-secret
+            secretName: {{ template "gafaelfawr.fullname" . }}-secret

--- a/charts/gafaelfawr/templates/deployment.yaml
+++ b/charts/gafaelfawr/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: gafaelfawr
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:
             - containerPort: 8080

--- a/charts/gafaelfawr/templates/deployment.yaml
+++ b/charts/gafaelfawr/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "gafaelfawr.selectorLabels" . | nindent 6 }}
@@ -14,24 +14,44 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "frontend"
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
       containers:
-        - name: gafaelfawr
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          ports:
-            - containerPort: 8080
-              name: "app"
+        - name: "gafaelfawr"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - "all"
             readOnlyRootFilesystem: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          ports:
+            - containerPort: 8080
+              name: "http"
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: "http"
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: "config"
               mountPath: "/etc/gafaelfawr"
@@ -39,14 +59,6 @@ spec:
             - name: "secret"
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
-      {{- if .Values.pullSecret }}
-      imagePullSecrets:
-        - name: {{ .Values.pullSecret | quote }}
-      {{- end }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
       volumes:
         - name: "config"
           configMap:
@@ -54,3 +66,15 @@ spec:
         - name: "secret"
           secret:
             secretName: {{ template "gafaelfawr.fullname" . }}-secret
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/gafaelfawr/templates/deployment.yaml
+++ b/charts/gafaelfawr/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: gafaelfawr
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           ports:
             - containerPort: 8080
               name: "app"
@@ -33,10 +33,10 @@ spec:
                 - "all"
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: {{ template "gafaelfawr.fullname" . }}-config
+            - name: "config"
               mountPath: "/etc/gafaelfawr"
               readOnly: true
-            - name: {{ template "gafaelfawr.fullname" . }}-secret
+            - name: "secret"
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
       {{- if .Values.pullSecret }}
@@ -48,9 +48,9 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
       volumes:
-        - name: {{ template "gafaelfawr.fullname" . }}-config
+        - name: "config"
           configMap:
-            name: {{ template "gafaelfawr.fullname" . }}-configmap
-        - name: {{ template "gafaelfawr.fullname" . }}-secret
+            name: {{ template "gafaelfawr.fullname" . }}-config
+        - name: "secret"
           secret:
             secretName: {{ template "gafaelfawr.fullname" . }}-secret

--- a/charts/gafaelfawr/templates/deployment.yaml
+++ b/charts/gafaelfawr/templates/deployment.yaml
@@ -39,9 +39,9 @@ spec:
             - name: {{ template "gafaelfawr.fullname" . }}-secret
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
-      {{- if .Values.pull_secret }}
+      {{- if .Values.pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.pull_secret }}
+        - name: {{ .Values.pullSecret | quote }}
       {{- end }}
       securityContext:
         runAsNonRoot: true

--- a/charts/gafaelfawr/templates/deployment.yaml
+++ b/charts/gafaelfawr/templates/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       app.kubernetes.io/component: "frontend"
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "frontend"

--- a/charts/gafaelfawr/templates/ingress-token.yaml
+++ b/charts/gafaelfawr/templates/ingress-token.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   annotations:

--- a/charts/gafaelfawr/templates/ingress-token.yaml
+++ b/charts/gafaelfawr/templates/ingress-token.yaml
@@ -2,26 +2,26 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/auth-request-redirect: $request_uri
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
-    nginx.ingress.kubernetes.io/auth-signin: https://{{ .Values.host }}/login
-    nginx.ingress.kubernetes.io/auth-url: http://gafaelfawr-service.{{ .Release.Namespace }}.svc.cluster.local:8080/auth?scope={{ .Values.user_scope }}
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/auth-request-redirect: "$request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
+    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.host }}/login"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.{{ .Release.Namespace }}.svc.cluster.local:8080/auth?scope={{ .Values.config.userScope }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      error_page 403 = "/auth/forbidden?scope={{ .Values.user_scope }}";
+      error_page 403 = "/auth/forbidden?scope={{ .Values.config.userScope }}";
   name: {{ template "gafaelfawr.fullname" . }}-token-ingress
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
   rules:
-{{ if .Values.ingress.host }}
-  - host: {{ .Values.ingress.host }}
-    http:
-{{ else }}
-  - http:
-{{ end }}
+    {{- if .Values.ingress.host }}
+    - host: {{ .Values.ingress.host }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
       paths:
-      - path: /auth/token
-        backend:
-          serviceName: {{ template "gafaelfawr.fullname" . }}-service
-          servicePort: 8080
+        - path: "/auth/token"
+          backend:
+            serviceName: {{ template "gafaelfawr.fullname" . }}-service
+            servicePort: 8080

--- a/charts/gafaelfawr/templates/ingress-token.yaml
+++ b/charts/gafaelfawr/templates/ingress-token.yaml
@@ -9,7 +9,9 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: http://gafaelfawr-service.{{ .Release.Namespace }}.svc.cluster.local:8080/auth?scope={{ .Values.user_scope }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       error_page 403 = "/auth/forbidden?scope={{ .Values.user_scope }}";
-  name: {{ template "helpers.fullname" . }}-token-ingress
+  name: {{ template "gafaelfawr.fullname" . }}-token-ingress
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
   rules:
 {{ if .Values.ingress.host }}
@@ -21,5 +23,5 @@ spec:
       paths:
       - path: /auth/token
         backend:
-          serviceName: {{ template "helpers.fullname" . }}-service
+          serviceName: {{ template "gafaelfawr.fullname" . }}-service
           servicePort: 8080

--- a/charts/gafaelfawr/templates/ingress-token.yaml
+++ b/charts/gafaelfawr/templates/ingress-token.yaml
@@ -9,6 +9,9 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.{{ .Release.Namespace }}.svc.cluster.local:8080/auth?scope={{ .Values.config.userScope }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       error_page 403 = "/auth/forbidden?scope={{ .Values.config.userScope }}";
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ template "gafaelfawr.fullname" . }}-token-ingress
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -2,8 +2,10 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
-  name: {{ template "helpers.fullname" . }}-ingress
+    kubernetes.io/ingress.class: "nginx"
+  name: {{ template "gafaelfawr.fullname" . }}-ingress
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
   rules:
 {{ if .Values.ingress.host }}
@@ -13,29 +15,29 @@ spec:
   - http:
 {{ end }}
       paths:
-      - path: /auth
+      - path: "/auth"
         backend:
-          serviceName: {{ template "helpers.fullname" . }}-service
+          serviceName: {{ template "gafaelfawr.fullname" . }}-service
           servicePort: 8080
-      - path: /login
+      - path: "/login"
         backend:
-          serviceName: {{ template "helpers.fullname" . }}-service
+          serviceName: {{ template "gafaelfawr.fullname" . }}-service
           servicePort: 8080
-      - path: /logout
+      - path: "/logout"
         backend:
-          serviceName: {{ template "helpers.fullname" . }}-service
+          serviceName: {{ template "gafaelfawr.fullname" . }}-service
           servicePort: 8080
-      - path: /oauth2/callback
+      - path: "/oauth2/callback"
         backend:
-          serviceName: {{ template "helpers.fullname" . }}-service
+          serviceName: {{ template "gafaelfawr.fullname" . }}-service
           servicePort: 8080
-      - path: /.well-known/jwks.json
+      - path: "/.well-known/jwks.json"
         backend:
-          serviceName: {{ template "helpers.fullname" . }}-service
+          serviceName: {{ template "gafaelfawr.fullname" . }}-service
           servicePort: 8080
       {{- if .Values.oidc_server.enabled }}
-      - path: /.well-known/openid-configuration
+      - path: "/.well-known/openid-configuration"
         backend:
-          serviceName: {{ template "helpers.fullname" . }}-service
+          serviceName: {{ template "gafaelfawr.fullname" . }}-service
           servicePort: 8080
       {{- end }}

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -3,6 +3,9 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ template "gafaelfawr.fullname" . }}
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
@@ -41,3 +44,13 @@ spec:
             serviceName: {{ template "gafaelfawr.fullname" . }}
             servicePort: 8080
         {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   annotations:

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -3,41 +3,41 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
-  name: {{ template "gafaelfawr.fullname" . }}-ingress
+  name: {{ template "gafaelfawr.fullname" . }}
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
   rules:
-{{ if .Values.ingress.host }}
-  - host: {{ .Values.ingress.host }}
-    http:
-{{ else }}
-  - http:
-{{ end }}
+    {{- if .Values.ingress.host }}
+    - host: {{ .Values.ingress.host }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
       paths:
-      - path: "/auth"
-        backend:
-          serviceName: {{ template "gafaelfawr.fullname" . }}-service
-          servicePort: 8080
-      - path: "/login"
-        backend:
-          serviceName: {{ template "gafaelfawr.fullname" . }}-service
-          servicePort: 8080
-      - path: "/logout"
-        backend:
-          serviceName: {{ template "gafaelfawr.fullname" . }}-service
-          servicePort: 8080
-      - path: "/oauth2/callback"
-        backend:
-          serviceName: {{ template "gafaelfawr.fullname" . }}-service
-          servicePort: 8080
-      - path: "/.well-known/jwks.json"
-        backend:
-          serviceName: {{ template "gafaelfawr.fullname" . }}-service
-          servicePort: 8080
-      {{- if .Values.oidc_server.enabled }}
-      - path: "/.well-known/openid-configuration"
-        backend:
-          serviceName: {{ template "gafaelfawr.fullname" . }}-service
-          servicePort: 8080
-      {{- end }}
+        - path: "/auth"
+          backend:
+            serviceName: {{ template "gafaelfawr.fullname" . }}
+            servicePort: 8080
+        - path: "/login"
+          backend:
+            serviceName: {{ template "gafaelfawr.fullname" . }}
+            servicePort: 8080
+        - path: "/logout"
+          backend:
+            serviceName: {{ template "gafaelfawr.fullname" . }}
+            servicePort: 8080
+        - path: "/oauth2/callback"
+          backend:
+            serviceName: {{ template "gafaelfawr.fullname" . }}
+            servicePort: 8080
+        - path: "/.well-known/jwks.json"
+          backend:
+            serviceName: {{ template "gafaelfawr.fullname" . }}
+            servicePort: 8080
+        {{- if .Values.config.oidcServer.enabled }}
+        - path: "/.well-known/openid-configuration"
+          backend:
+            serviceName: {{ template "gafaelfawr.fullname" . }}
+            servicePort: 8080
+        {{- end }}

--- a/charts/gafaelfawr/templates/redis-deployment.yaml
+++ b/charts/gafaelfawr/templates/redis-deployment.yaml
@@ -19,8 +19,8 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: "redis"
-          image: "redis"
-          imagePullPolicy: "Always"
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy | quote }}
           args:
             - "redis-server"
             - "--appendonly"

--- a/charts/gafaelfawr/templates/redis-deployment.yaml
+++ b/charts/gafaelfawr/templates/redis-deployment.yaml
@@ -1,23 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: {{ template "gafaelfawr.fullname" . }}-redis
   labels:
-    app: {{ template "helpers.fullname" . }}-redis
-  name: {{ template "helpers.fullname" . }}-redis
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "helpers.fullname" . }}-redis
+      {{- include "gafaelfawr.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "redis"
   template:
     metadata:
       labels:
-        app: {{ template "helpers.fullname" . }}-redis
+        {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "redis"
     spec:
       automountServiceAccountToken: false
       containers:
-        - name: redis
-          image: redis
+        - name: "redis"
+          image: "redis"
           imagePullPolicy: "Always"
           args:
             - "redis-server"
@@ -29,7 +31,7 @@ spec:
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "helpers.fullname" . }}-secret
+                  name: {{ template "gafaelfawr.fullname" . }}-secret
                   key: "redis-password"
           livenessProbe:
             exec:
@@ -50,14 +52,14 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - all
+                - "all"
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: redis-data
+            - name: "redis-data"
               mountPath: "/data"
       {{- if .Values.pull_secret }}
       imagePullSecrets:
-      - name: {{ .Values.pull_secret }}
+        - name: {{ .Values.pull_secret }}
       {{- end }}
       securityContext:
         fsGroup: 999

--- a/charts/gafaelfawr/templates/redis-networkpolicy.yaml
+++ b/charts/gafaelfawr/templates/redis-networkpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-redis-networkpolicy
+  name: {{ template "gafaelfawr.fullname" . }}-redis
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:

--- a/charts/gafaelfawr/templates/redis-networkpolicy.yaml
+++ b/charts/gafaelfawr/templates/redis-networkpolicy.yaml
@@ -1,11 +1,14 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ template "helpers.fullname" . }}-redis-networkpolicy
+  name: {{ template "gafaelfawr.fullname" . }}-redis-networkpolicy
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ template "helpers.fullname" . }}-redis
+      {{- include "gafaelfawr.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "redis"
   policyTypes:
     - Ingress
     - Egress
@@ -13,7 +16,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              name: {{ template "helpers.fullname" . }}
+              {{- include "gafaelfawr.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "frontend"
       ports:
-        - protocol: TCP
+        - protocol: "TCP"
           port: 6379

--- a/charts/gafaelfawr/templates/redis-service.yml
+++ b/charts/gafaelfawr/templates/redis-service.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-redis-service
+  name: {{ template "gafaelfawr.fullname" . }}-redis
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:

--- a/charts/gafaelfawr/templates/redis-service.yml
+++ b/charts/gafaelfawr/templates/redis-service.yml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-  name: {{ template "helpers.fullname" . }}-redis-service
+  name: {{ template "gafaelfawr.fullname" . }}-redis-service
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
+  type: ClusterIP
   ports:
     - port: 6379
-      protocol: TCP
+      protocol: "TCP"
       targetPort: 6379
   selector:
-    app: {{ template "helpers.fullname" . }}-redis
+    {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "redis"
   sessionAffinity: None
-  type: ClusterIP
-status:
-  loadBalancer: {}

--- a/charts/gafaelfawr/templates/redis-statefulset.yaml
+++ b/charts/gafaelfawr/templates/redis-statefulset.yaml
@@ -13,10 +13,23 @@ spec:
   serviceName: "redis"
   template:
     metadata:
+      {{- with .Values.redis.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "gafaelfawr.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "redis"
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        fsGroup: 999
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
       automountServiceAccountToken: false
       containers:
         - name: "redis"
@@ -58,15 +71,6 @@ spec:
           volumeMounts:
             - name: {{ template "gafaelfawr.fullname" . }}-redis-data
               mountPath: "/data"
-      {{- if .Values.redis.pullSecret }}
-      imagePullSecrets:
-        - name: {{ .Values.redis.pullSecret | quote }}
-      {{- end }}
-      securityContext:
-        fsGroup: 999
-        runAsNonRoot: true
-        runAsUser: 999
-        runAsGroup: 999
       {{- if (not .Values.redis.persistence.enabled) }}
       volumes:
         - name: {{ template "gafaelfawr.fullname" . }}-redis-data
@@ -76,6 +80,18 @@ spec:
         - name: {{ template "gafaelfawr.fullname" . }}-redis-data
           persistentVolumeClaim:
             claimName: {{ .Values.redis.persistence.volumeClaimName | quote }}
+      {{- end }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- if (and .Values.redis.persistence.enabled (not .Values.redis.persistence.volumeClaimName)) }}
   volumeClaimTemplates:

--- a/charts/gafaelfawr/templates/redis-statefulset.yaml
+++ b/charts/gafaelfawr/templates/redis-statefulset.yaml
@@ -58,9 +58,9 @@ spec:
           volumeMounts:
             - name: {{ template "gafaelfawr.fullname" . }}-redis-data
               mountPath: "/data"
-      {{- if .Values.pull_secret }}
+      {{- if .Values.redis.pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.pull_secret }}
+        - name: {{ .Values.redis.pullSecret | quote }}
       {{- end }}
       securityContext:
         fsGroup: 999

--- a/charts/gafaelfawr/templates/redis-statefulset.yaml
+++ b/charts/gafaelfawr/templates/redis-statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "gafaelfawr.fullname" . }}-redis
   labels:
@@ -10,6 +10,7 @@ spec:
     matchLabels:
       {{- include "gafaelfawr.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: "redis"
+  serviceName: "redis"
   template:
     metadata:
       labels:
@@ -55,7 +56,7 @@ spec:
                 - "all"
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: "redis-data"
+            - name: {{ template "gafaelfawr.fullname" . }}-redis-data
               mountPath: "/data"
       {{- if .Values.pull_secret }}
       imagePullSecrets:
@@ -66,11 +67,27 @@ spec:
         runAsNonRoot: true
         runAsUser: 999
         runAsGroup: 999
+      {{- if (not .Values.redis.persistence.enabled) }}
       volumes:
-        - name: redis-data
-          {{- if .Values.redis_claim }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.redis_claim }}
-          {{- else }}
+        - name: {{ template "gafaelfawr.fullname" . }}-redis-data
           emptyDir: {}
-          {{- end }}
+      {{- else if .Values.redis.persistence.volumeClaimName }}
+      volumes:
+        - name: {{ template "gafaelfawr.fullname" . }}-redis-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.redis.persistence.volumeClaimName | quote }}
+      {{- end }}
+  {{- if (and .Values.redis.persistence.enabled (not .Values.redis.persistence.volumeClaimName)) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ template "gafaelfawr.fullname" . }}-redis-data
+      spec:
+        accessModes:
+          - {{ .Values.redis.persistence.accessMode | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size | quote }}
+        {{- if .Values.redis.persistence.storageClass }}
+        storageClassName: {{ .Values.redis.persistence.storageClass | quote }}
+        {{- end }}
+  {{- end }}

--- a/charts/gafaelfawr/templates/service.yaml
+++ b/charts/gafaelfawr/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - protocol: "TCP"
       port: 8080
-      targetPort: "app"
+      targetPort: "http"
   selector:
     {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "frontend"
@@ -26,7 +26,7 @@ spec:
   ports:
     - protocol: "TCP"
       port: 8080
-      targetPort: "app"
+      targetPort: "http"
   selector:
     {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "frontend"

--- a/charts/gafaelfawr/templates/service.yaml
+++ b/charts/gafaelfawr/templates/service.yaml
@@ -1,6 +1,23 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ template "gafaelfawr.fullname" . }}
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: "TCP"
+      port: 8080
+      targetPort: "app"
+  selector:
+    {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "frontend"
+  sessionAffinity: None
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: {{ template "gafaelfawr.fullname" . }}-service
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}

--- a/charts/gafaelfawr/templates/service.yaml
+++ b/charts/gafaelfawr/templates/service.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "helpers.fullname" . }}-service
+  name: {{ template "gafaelfawr.fullname" . }}-service
   labels:
-    app: {{ template "helpers.fullname" . }}
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
-  ports:
-  - name: {{ template "helpers.fullname" . }}-http
-    protocol: TCP
-    port: 8080
-    targetPort: app
-  selector:
-    name: {{ template "helpers.fullname" . }}
-  sessionAffinity: None
   type: ClusterIP
+  ports:
+    - protocol: "TCP"
+      port: 8080
+      targetPort: "app"
+  selector:
+    {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "frontend"
+  sessionAffinity: None

--- a/charts/gafaelfawr/templates/vault-secret.yaml
+++ b/charts/gafaelfawr/templates/vault-secret.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
-  path: {{ .Values.vault_secrets_path | quote }}
+  path: {{ required "vaultSecretsPath must be set" .Values.vaultSecretsPath | quote }}
   type: Opaque

--- a/charts/gafaelfawr/templates/vault-secret.yaml
+++ b/charts/gafaelfawr/templates/vault-secret.yaml
@@ -1,7 +1,9 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: {{ template "helpers.fullname" . }}-secret
+  name: {{ template "gafaelfawr.fullname" . }}-secret
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
 spec:
-  path: {{ .Values.vault_secrets_path }}
+  path: {{ .Values.vault_secrets_path | quote }}
   type: Opaque

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -6,8 +6,10 @@ ingress:
 # image configures the Docker image to use
 image:
   repository: "lsstsqre/gafaelfawr"
-  tag: "1.5.0"
   pullPolicy: "IfNotPresent"
+
+  # image.tag overrides the default, which is the chart appVersion
+  tag: null
 
 # redis configures the internal Redis service
 redis:

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -2,9 +2,9 @@
 # e.g. lsst-lsp-<instance>.ncsa.illinois.edu
 host: ""
 
-# Controls the host for the ingress.  Normally set to the same value as
-# the realm, but leave blank for environments using the wildcard virtual
-# host (such as nublado.lsst.codes).
+# Controls the host for the ingress.  Normally set to the same value as the
+# realm, but leave blank for environments using the wildcard virtual host
+# (such as nublado.lsst.codes).
 ingress:
   host: ""
 
@@ -21,9 +21,21 @@ redis:
     tag: "6.2.1"
     pullPolicy: "IfNotPresent"
 
-# Existing PVC for redis claim
-# If empty, redis will use emptydir
-redis_claim: ""
+  # By default, Redis will use dynamic provisioning of persistent storage and
+  # request 1Gi of storage (which should be more than enough) using the
+  # default storage class.
+  #
+  # To disable persistence entirely and use emptyDir, which will reset storage
+  # on every restart (suitable only for a test deployment), set
+  # redis.persistence.enabled to false.
+  persistence:
+    enabled: true
+    size: "1Gi"
+    storageClass: null
+    accessMode: "ReadWriteOnce"
+
+    # volumeClaimName says to use an existing PVC, not dynamic provisioning.
+    volumeClaimName: null
 
 # Path to the Vault secret to use to generate Kubernetes secrets.
 # secret/k8s_operator/<host>/gafaelfawr

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -14,6 +14,13 @@ image:
   tag: "1.5.0"
   pullPolicy: "IfNotPresent"
 
+# redis configures the internal Redis service.
+redis:
+  image:
+    repository: "redis"
+    tag: "6.2.1"
+    pullPolicy: "IfNotPresent"
+
 # Existing PVC for redis claim
 # If empty, redis will use emptydir
 redis_claim: ""

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -1,7 +1,10 @@
-# ingress.host sets the hostname for the ingress.  This should normally be the
-# same as config.host.
-ingress:
-  host: null
+# Default values for Gafaelfawr.
+
+replicaCount: 1
+
+# nameOverride and fullnameOverride change the naming of chart resources
+nameOverride: ""
+fullnameOverride: ""
 
 # image configures the Docker image to use
 image:
@@ -9,42 +12,42 @@ image:
   pullPolicy: "IfNotPresent"
 
   # image.tag overrides the default, which is the chart appVersion
-  tag: null
+  tag: ""
 
-# redis configures the internal Redis service
-redis:
-  image:
-    repository: "redis"
-    tag: "6.2.1"
-    pullPolicy: "IfNotPresent"
+# imagePullSecrets list secret names to use for all Docker pulls
+imagePullSecrets: []
 
-  # By default, Redis will use dynamic provisioning of persistent storage and
-  # request 1Gi of storage (which should be more than enough) using the
-  # default storage class.
-  #
-  # To disable persistence entirely and use emptyDir, which will reset storage
-  # on every restart (suitable only for a test deployment), set
-  # redis.persistence.enabled to false.
-  persistence:
-    enabled: true
-    size: "1Gi"
-    storageClass: null
-    accessMode: "ReadWriteOnce"
+# ingress configures the ingress, which is enabled by default.
+ingress:
+  enabled: true
+  annotations: {}
 
-    # volumeClaimName says to use an existing PVC, not dynamic provisioning.
-    volumeClaimName: null
+  # ingress.host sets the hostname for the ingress.
+  # This should normally be the same as config.host.
+  host: ""
 
-# pullSecret defines a secret name to use for all Docker pulls
-pullSecret: null
+  # ingress.tls configures TLS for the ingress if needed.
+  # If multiple ingresses share the same hostname, only one of them needs a
+  # TLS configuration.
+  tls: []
 
-# vaultSecretsPath sets the path to the Vault secret for Gafaelfawr
+# resources defines resource limits and requests
+resources: {}
+
+# Additional optional configuration for how to deploy Gafaelfawr pods
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# vaultSecretsPath sets the path to the Vault secret and must be set
 # secret/k8s_operator/<host>/gafaelfawr
-vaultSecretsPath: null
+vaultSecretsPath: ""
 
 # config specifies the Gafaelfawr configuration
 config:
   # config.host is used to construct issuers and URLs and must be set
-  host: null
+  host: ""
 
   # Choose from the text form of Python logging levels.
   loglevel: "INFO"
@@ -84,7 +87,7 @@ config:
     # identity of the user requesting a token.
     influxdb:
       enabled: false
-      username: null
+      username: ""
 
   # Whether to support OpenID Connect clients.  If set to true,
   # oidc-server-secrets must be set in the Gafaelfawr secret.
@@ -109,3 +112,32 @@ config:
   # include groups in an isMemberOf claim will be granted scopes based on this
   # mapping.
   groupMapping: {}
+
+# redis configures the internal Redis service
+redis:
+  image:
+    repository: "redis"
+    tag: "6.2.1"
+    pullPolicy: "IfNotPresent"
+
+  # By default, Redis will use dynamic provisioning of persistent storage and
+  # request 1Gi of storage (which should be more than enough) using the
+  # default storage class.
+  #
+  # To disable persistence entirely and use emptyDir, which will reset storage
+  # on every restart (suitable only for a test deployment), set
+  # redis.persistence.enabled to false.
+  persistence:
+    enabled: true
+    size: "1Gi"
+    storageClass: ""
+    accessMode: "ReadWriteOnce"
+
+    # volumeClaimName says to use an existing PVC, not dynamic provisioning.
+    volumeClaimName: ""
+
+  # Additional optional configuration for how to deploy the Redis pod
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -1,20 +1,15 @@
-# Hostname used to construct issuers and URLs.
-# e.g. lsst-lsp-<instance>.ncsa.illinois.edu
-host: ""
-
-# Controls the host for the ingress.  Normally set to the same value as the
-# realm, but leave blank for environments using the wildcard virtual host
-# (such as nublado.lsst.codes).
+# ingress.host sets the hostname for the ingress.  This should normally be the
+# same as config.host.
 ingress:
-  host: ""
+  host: null
 
-# Docker image to use.
+# image configures the Docker image to use
 image:
   repository: "lsstsqre/gafaelfawr"
   tag: "1.5.0"
   pullPolicy: "IfNotPresent"
 
-# redis configures the internal Redis service.
+# redis configures the internal Redis service
 redis:
   image:
     repository: "redis"
@@ -37,89 +32,78 @@ redis:
     # volumeClaimName says to use an existing PVC, not dynamic provisioning.
     volumeClaimName: null
 
-# Path to the Vault secret to use to generate Kubernetes secrets.
+# pullSecret defines a secret name to use for all Docker pulls
+pullSecret: null
+
+# vaultSecretsPath sets the path to the Vault secret for Gafaelfawr
 # secret/k8s_operator/<host>/gafaelfawr
-vault_secrets_path: ""
+vaultSecretsPath: null
 
-# Default scope required for user-based operations (like generating a
-# token), used to construct authorization URLs for the /tokens route.
-user_scope: "exec:user"
+# config specifies the Gafaelfawr configuration
+config:
+  # config.host is used to construct issuers and URLs and must be set
+  host: null
 
-# Choose from the text form of Python logging levels.
-loglevel: INFO
+  # Choose from the text form of Python logging levels.
+  loglevel: "INFO"
 
-# Pull secret name
-pull_secret: ""
+  # List of netblocks used for internal Kubernetes IP addresses, used to
+  # determine the true client IP for logging.
+  proxies:
+    - "10.0.0.0/8"
+    - "172.16.0.0/12"
+    - "192.168.0.0/16"
 
-# List of netblocks used for internal Kubernetes IP addresses, used to
-# determine the true client IP for logging.
-proxies:
-  - "10.0.0.0/8"
-  - "172.16.0.0/12"
-  - "192.168.0.0/16"
+  # Example configuration for using CILogon.
+  # cilogon:
+  #   clientId: "cilogon:/client_id/<some-id>"
+  #
+  #   # If the registered URL is different from /login (the default).
+  #   redirectUrl: "https://<hostname>/oauth2/callback"
+  #
+  #   # Whether to use the test instance.
+  #   test: false
+  #
+  #   # Additional parameters to add.
+  #   loginParams:
+  #     skin: "LSST"
 
-# Example configuration for using CILogon.
-# cilogon:
-#   client_id: "cilogon:/client_id/<some-id>"
-#
-#   # If the registered URL is different from /login (the default).
-#   redirect_url: "https://<hostname>/oauth2/callback"
-#
-#   # Whether to use the test instance.
-#   test: false
-#
-#   # Additional parameters to add.
-#   login_params:
-#     skin: "LSST"
+  # Example configuration for using GitHub.
+  # github:
+  #   clientId: "<github-client-id>"
 
-# Example configuration for using GitHub.
-# github:
-#   client_id: "<github-client-id>"
+  issuer:
+    # Session length and token expiration (in minutes).
+    expMinutes: 43200  # 30 days
 
-issuer:
-  # Session length and token expiration (in minutes).
-  exp_minutes: 1440  # 1 day
+    # Whether to issue tokens for InfluxDB.  If set to true, influxdb-secret
+    # must be set in the Gafaelfawr secret.  If username is also set, force
+    # all InfluxDB tokens to have that username instead of the authenticated
+    # identity of the user requesting a token.
+    influxdb:
+      enabled: false
+      username: null
 
-  # Whether to issue tokens for InfluxDB.  If set to true, influxdb-secret
-  # must be set in the Gafaelfawr secret.  If username is also set, force
-  # all InfluxDB tokens to have that username instead of the authenticated
-  # identity of the user requesting a token.
-  influxdb:
+  # Whether to support OpenID Connect clients.  If set to true,
+  # oidc-server-secrets must be set in the Gafaelfawr secret.
+  oidcServer:
     enabled: false
-    username: ""
 
-# Whether to support OpenID Connect clients.  If set to true,
-# oidc-server-secrets must be set in the Gafaelfawr secret.
-oidc_server:
-  enabled: false
+  # config.userScope sets the scope required to access the /auth/tokens route
+  userScope: "exec:user"
 
-# Names and descriptions of all scopes in use.  This is used to populate
-# the new token creation page.  Only scopes listed here will be options
-# when creating a new token.
-known_scopes:
-  "exec:admin": Administrative access to all APIs.
-  "exec:portal": Use the Portal to execute operations. Mostly used from notebook APIs.
-  "read:image": Read images from the SODA and other image retrieval interfaces
-  "read:image/metadata": Read image metadata from SIA and other image interfaces
-  "read:tap": Execute SELECT queries in the TAP interface on project datasets
-  "read:tap/efd": Execute SELECT queries in the TAP interface on EFD datasets
-  "read:tap/user": Execute SELECT queries in the TAP interface on your data
-  "write:tap/user": Upload tables to your database workspace
-  "read:tap/history": Read the history of your TAP queries.
-  "read:workspace": Read project datasets from the file workspace
-  "read:workspace/user": Read the data in your file workspace
-  "write:workspace/user": Write data to your file workspace
+  # config.knownScopes defines the names and descriptions of all scopes in
+  # use.  This is used to populate the new token creation page.  Only scopes
+  # listed here will be options when creating a new token.
+  knownScopes:
+    "exec:admin": Administrative access to all APIs
+    "exec:notebook": Use the Notebook Aspect
+    "exec:portal": Use the Portal Aspect
+    "exec:user": Create and manage user tokens for your user
+    "read:tap": Execute SELECT queries in the TAP interface on project datasets
 
-# Mapping of scopes to groups that provide that scope.  Tokens from an
-# OpenID Connect provider such as CILogon that include groups in an
-# isMemberOf claim will be granted scopes based on this mapping.
-group_mapping:
-  "exec:admin": ["lsst_int_lsp_admin"]
-  "exec:user": ["lsst_int_lspdev"]
-  "read:workspace": ["lsst_int_lspdev"]
-  "read:workspace/user": ["lsst_int_lspdev"]
-  "write:workspace/user": ["lsst_int_lspdev"]
-  "exec:portal": ["lsst_int_lspdev"]
-  "exec:notebook": ["lsst_int_lspdev"]
-  "read:tap": ["lsst_int_lspdev"]
-  "read:image": ["lsst_int_lspdev"]
+  # config.groupMapping defines a mapping of scopes to groups that provide
+  # that scope.  Tokens from an OpenID Connect provider such as CILogon that
+  # include groups in an isMemberOf claim will be granted scopes based on this
+  # mapping.
+  groupMapping: {}


### PR DESCRIPTION
- Rework the Helm chart to follow best practices
- Rename resources to remove useless suffixes (keeping both the old and new service for now)
- Restructure `values.yaml` and use camelCase per Helm best practices
- Convert Redis to a `StatefulSet` to avoid volume mount conflicts with persistent volumes
- Add support for persistent volume templates, which we'll use for Redis in the IDF
- Use the new `apiVersion` for `Ingress` resources where appropriate
- Default the image tag to the `appVersion` in the chart
- Pin the version of Redis for smoother upgrade management
- Restart Gafaelfawr pods on configmap changes