### PR TITLE
[DM-29085] Fix the Gafaelfawr token ingress

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 2.0.1
+version: 2.0.2
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/ingress-token.yaml
+++ b/charts/gafaelfawr/templates/ingress-token.yaml
@@ -9,8 +9,8 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/auth-request-redirect: "$request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.host }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.{{ .Release.Namespace }}.svc.cluster.local:8080/auth?scope={{ .Values.config.userScope }}"
+    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.config.host }}/login"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.{{ .Release.Namespace }}.svc.cluster.local:8080/auth?scope={{ .Values.config.userScope }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       error_page 403 = "/auth/forbidden?scope={{ .Values.config.userScope }}";
     {{- with .Values.ingress.annotations }}
@@ -28,7 +28,7 @@ spec:
     - http:
     {{- end }}
         paths:
-          - path: "/auth/token"
+          - path: "/auth/tokens"
             backend:
               serviceName: {{ template "gafaelfawr.fullname" . }}
               servicePort: 8080


### PR DESCRIPTION
The auth-url link was invalid because it was interpolating the
wrong configuration variable, it was still pointing to the old
service name, and the path was slightly incorrect.