### PR TITLE
[DM-29085] Allow external host for token ingress auth-url

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 2.0.2
+version: 2.0.3
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/ci/values-stable.yaml
+++ b/charts/gafaelfawr/ci/values-stable.yaml
@@ -2,6 +2,7 @@ imagePullSecrets:
   - "pull-secret"
 ingress:
   host: "lsst-lsp-stable.ncsa.illinois.edu"
+  externalAuthUrl: true
 vaultSecretsPath: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/gafaelfawr"
 
 # Use an existing, manually-managed PVC for Redis.

--- a/charts/gafaelfawr/templates/ingress-token.yaml
+++ b/charts/gafaelfawr/templates/ingress-token.yaml
@@ -10,7 +10,11 @@ metadata:
     nginx.ingress.kubernetes.io/auth-request-redirect: "$request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.config.host }}/login"
+    {{- if .Values.ingress.externalAuthUrl }}
+    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.config.host }}/auth?scope={{ .Values.config.userScope }}"
+    {{- else }}
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.{{ .Release.Namespace }}.svc.cluster.local:8080/auth?scope={{ .Values.config.userScope }}"
+    {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       error_page 403 = "/auth/forbidden?scope={{ .Values.config.userScope }}";
     {{- with .Values.ingress.annotations }}

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -31,6 +31,11 @@ ingress:
   # TLS configuration.
   tls: []
 
+  # Temporary to allow values files to request use of the external hostname
+  # for the auth-url annotation on the token ingress because the internal
+  # hostname doesn't resolve at NCSA for some reason.
+  externalAuthUrl: false
+
 # resources defines resource limits and requests
 resources: {}
 


### PR DESCRIPTION
NCSA int (and presumably also stable) cannot resolve the internal
service hostname when used in an auth-url annotation.  Add a
parameter to change it to use the external hostname instead.  (We
can't do this everywhere because it doesn't work with minikube
for other DNS resolution reasons.)