### PR TITLE
DM-29432: squareone chart 0.1.1

### DIFF
--- a/charts/squareone/Chart.yaml
+++ b/charts/squareone/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/squareone/templates/ingress.yaml
+++ b/charts/squareone/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: {{ template "gafaelfawr.fullname" . }}
-              servicePort: 3000
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
     {{- end }}
   {{- end }}

--- a/charts/squareone/templates/ingress.yaml
+++ b/charts/squareone/templates/ingress.yaml
@@ -27,13 +27,11 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
           - path: /
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-    {{- end }}
   {{- end }}

--- a/charts/squareone/values.yaml
+++ b/charts/squareone/values.yaml
@@ -47,9 +47,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths: []
+  host: "chart-example.local"
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/squareone/values.yaml
+++ b/charts/squareone/values.yaml
@@ -43,7 +43,7 @@ service:
   port: 80
 
 ingress:
-  enabled: false
+  enabled: true
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
This chart release fixes issues with the ingress:

- enables ingress by default
- change to a single host name, which also means that the host name can be used correctly to configure the app itself
- ensure the ingress port matches the service port