### PR TITLE
[DM-29612] Fix the logout URL for Firefly

### DIFF
--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -5,4 +5,4 @@ name: firefly
 home: https://github.com/Caltech-IPAC/firefly
 maintainers:
   - name: cbanek
-version: 0.2.0
+version: 0.2.1

--- a/charts/firefly/templates/deployment.yaml
+++ b/charts/firefly/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
               name: {{ include "firefly.fullname" . }}-secret
               key: ADMIN_PASSWORD
         - name: FIREFLY_OPTS
-          value: -Dvisualize.fits.search.path=/datasets -Dredis.host={{ include "firefly.fullname" . }}-redis
+          value: "-Dvisualize.fits.search.path=/datasets -Dredis.host={{ include "firefly.fullname" . }}-redis -Dsso.logout.url=/logout"
         - name: FIREFLY_SHARED_WORK_DIR
           value: /firefly/workarea
         - name: SERVER_CONFIG_DIR


### PR DESCRIPTION
Override the current logout setting in the Firefly container,
which is pointing to the old oauth2_proxy URL, to use /logout
instead.