### PR TITLE
Fix Gafaelfawr redirect_url construction

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 2.0.3
+version: 2.0.4
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -63,7 +63,7 @@ data:
       {{- if .Values.config.cilogon.redirectUrl }}
       redirect_url: {{ .Values.config.cilogon.redirectUrl | quote }}
       {{- else }}
-      redirect_url: "https://{{ .Values.host }}/login"
+      redirect_url: "https://{{ .Values.config.host }}/login"
       {{- end }}
       scopes:
         - "email"


### PR DESCRIPTION
With OpenID Connect, the default redirect_url was incorrect because
it wasn't updated for the change in the values.yaml layout.