### PR TITLE
[DM-28120] Support new Gafaelfawr secret in mobu

### DIFF
--- a/charts/mobu/Chart.yaml
+++ b/charts/mobu/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 description: The mobu generates system load by pretending to be a random scientist
 home: https://github.com/lsst-sqre/mobu
 maintainers:
   - name: cbanek
 name: mobu
-version: 0.1.11
-appVersion: 1.0.10
+version: 0.2.0
+appVersion: 1.1.0

--- a/charts/mobu/templates/deployment.yaml
+++ b/charts/mobu/templates/deployment.yaml
@@ -35,10 +35,19 @@ spec:
                 secretKeyRef:
                   name: {{ template "mobu.fullname" . }}-mobu-secret
                   key: ALERT_HOOK
+            {{- if not .Values.gafaelfawrSecret }}
             - name: PRIVATE_KEY_PATH
               value: "/etc/secrets/signing-key"
+            {{- end }}
             - name: ENVIRONMENT_URL
               value: {{ .Values.environment_url }}
+            {{- if .Values.gafaelfawrSecret }}
+            - name: GAFAELFAWR_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.gafaelfawrSecret | quote }}
+                  key: "token"
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080
@@ -54,9 +63,11 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: "/tmp"
+            {{- if not .Values.gafaelfawrSecret }}
             - name: {{ template "mobu.fullname" . }}-gafaelfawr-secret
               mountPath: "/etc/secrets"
               readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -74,6 +85,8 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if not .Values.gafaelfawrSecret }}
         - name: {{ template "mobu.fullname" . }}-gafaelfawr-secret
           secret:
             secretName: {{ template "mobu.fullname" . }}-gafaelfawr-secret
+        {{- end }}

--- a/charts/mobu/templates/gafaelfawr-secret.yaml
+++ b/charts/mobu/templates/gafaelfawr-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.gafaelfawrSecret -}}
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
@@ -5,3 +6,4 @@ metadata:
 spec:
   path: {{ .Values.gafaelfawr_secrets_path }}
   type: Opaque
+{{- end }}

--- a/charts/mobu/values.yaml
+++ b/charts/mobu/values.yaml
@@ -12,6 +12,10 @@ image:
 mobu_secrets_path: ""
 gafaelfawr_secrets_path: ""
 
+# -- Name of the secret holding a Gafaelfawr token. Either this or
+# gafaelfawr_secrets_path must be set.
+gafaelfawrSecret: ""
+
 environment_url: ""
 
 nameOverride: ""


### PR DESCRIPTION
Provide a new configuration parameter, gafaelfawrSecret, that
specifies the name of a secret in the mobu namespace that will
contain the Gafaelfawr token.  If this is set, do not create the
Gafaelfawr vault secret in the mobu namespace or mount it as a
volume.

Once all installations have switched to Gafaelfawr 2.0, these
portions of the template can be deleted.

Also require Helm v3 for the chart (we're using that everywhere
already) and bump the mobu appVersion in anticipation of the mobu
release with GAFAELFAWR_TOKEN support.