### PR TITLE
[DM-28120] Update nublado2 for Gafaelfawr 2.0

### DIFF
--- a/charts/moneypenny/Chart.yaml
+++ b/charts/moneypenny/Chart.yaml
@@ -1,7 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: moneypenny
 maintainers:
   - name: athornton
-version: 0.0.2
+version: 0.0.3

--- a/charts/moneypenny/values.yaml
+++ b/charts/moneypenny/values.yaml
@@ -44,7 +44,7 @@ ingress:
   enabled: false
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:admin"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=admin:provision"
   hosts:
     - host: chart-example.local
       paths: ["/moneypenny"]
@@ -52,7 +52,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  
+
 orders: |
   commission:
     - name: farthing
@@ -81,7 +81,7 @@ quips: |
   forget.
   Bond: Yes?
   Moneypenny: I... love... you. Repeat it please, to make sure you get it.
-  Bond: Don't worry, I get it. Sayonara. 
+  Bond: Don't worry, I get it. Sayonara.
   %
   My problem is, James, you never do anything with me.
   %

--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,7 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 name: nublado2
-version: 0.0.28
-appVersion: 1.0.7
+version: 0.1.0
+appVersion: 1.1.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2
 maintainers:
@@ -10,3 +10,7 @@ sources:
   - https://github.com/lsst-sqre/nublado2
   - https://github.com/lsst-sqre/charts
 kubeVersion: '>=1.16.0-0'
+dependencies:
+  - name: jupyterhub
+    version: "0.9.0-n409.hce116620"
+    repository: https://jupyterhub.github.io/helm-chart/

--- a/charts/nublado2/requirements.yaml
+++ b/charts/nublado2/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: jupyterhub
-  version: "0.9.0-n409.hce116620"
-  repository: https://jupyterhub.github.io/helm-chart/

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -6,7 +6,7 @@ jupyterhub:
   hub:
     image:
       name: lsstsqre/nublado2
-      tag: "1.0.7"
+      tag: "1.1.0"
     containerSecurityContext:
       runAsUser: 768
       runAsGroup: 768
@@ -26,12 +26,18 @@ jupyterhub:
           name: nublado-config
       - name: nublado-gafaelfawr
         secret:
+          secretName: gafaelfawr-token
+      - name: nublado-gafealfawr-key
+        secret:
           secretName: nublado-gafaelfawr
     extraVolumeMounts:
       - name: nublado-config
         mountPath: /etc/jupyterhub/nublado_config.yaml
         subPath: nublado_config.yaml
       - name: nublado-gafaelfawr
+        mountPath: /etc/keys/gafaelfawr-token
+        subPath: token
+      - name: nublado-gafaelfawr-key
         mountPath: /etc/keys/signing_key.pem
         subPath: signing-key
     networkPolicy:


### PR DESCRIPTION
Mount the new Gafaelfawr token secret into the hub container as
well.  This means this version of the nublado2 chart can only be
deployed in environments that Gafaelfawr 2.0 has been deployed in.
Unfortunately, because most of the work in the chart is done in
values.yaml, we can't do better than that.

Change the scope used to protect moneypenny.

Change the chart to require Helm 3.  We're already using that
everywhere and know that it works with the upstream chart, even
though the upstream chart is still v1.