### PR TITLE
[DM-28120] Fix Gafaelfawr Cloud SQL Auth Proxy config

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 3.0.3
+version: 3.0.4
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/cronjob-tokens.yaml
+++ b/charts/gafaelfawr/templates/cronjob-tokens.yaml
@@ -31,6 +31,25 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
           containers:
+            {{- if .Values.cloudsql.enabled }}
+            - name: "cloud-sql-proxy"
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "all"
+                readOnlyRootFilesystem: true
+              image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+              imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+              command:
+                - "/cloud_sql_proxy"
+                - "-ip_address_types=PRIVATE"
+                - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+            {{- end }}
             - name: "gafaelfawr"
               securityContext:
                 allowPrivilegeEscalation: false
@@ -60,25 +79,6 @@ spec:
                 - name: "secret"
                   mountPath: "/etc/gafaelfawr/secrets"
                   readOnly: true
-            {{- if .Values.cloudsql.enabled }}
-            - name: "cloud-sql-proxy"
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - "all"
-                readOnlyRootFilesystem: true
-              image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
-              imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
-              command:
-                - "/cloud_sql_proxy"
-                - "-ip_address_type=PRIVATE"
-                - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
-              securityContext:
-                runAsNonRoot: true
-                runAsUser: 65532
-                runAsGroup: 65532
-            {{- end }}
           volumes:
             - name: "config"
               configMap:

--- a/charts/gafaelfawr/templates/deployment.yaml
+++ b/charts/gafaelfawr/templates/deployment.yaml
@@ -35,6 +35,25 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
       containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+        {{- end }}
         - name: "gafaelfawr"
           securityContext:
             allowPrivilegeEscalation: false
@@ -74,25 +93,6 @@ spec:
             - name: "secret"
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
-        {{- if .Values.cloudsql.enabled }}
-        - name: "cloud-sql-proxy"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
-            readOnlyRootFilesystem: true
-          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
-          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
-          command:
-            - "/cloud_sql_proxy"
-            - "-ip_address_type=PRIVATE"
-            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
-        {{- end }}
       volumes:
         - name: "config"
           configMap:

--- a/charts/gafaelfawr/templates/post-install-init.yaml
+++ b/charts/gafaelfawr/templates/post-install-init.yaml
@@ -27,6 +27,25 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
       containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+        {{- end }}
         - name: "gafaelfawr"
           securityContext:
             allowPrivilegeEscalation: false
@@ -56,25 +75,6 @@ spec:
             - name: "secret"
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
-        {{- if .Values.cloudsql.enabled }}
-        - name: "cloud-sql-proxy"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
-            readOnlyRootFilesystem: true
-          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
-          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
-          command:
-            - "/cloud_sql_proxy"
-            - "-ip_address_type=PRIVATE"
-            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
-        {{- end }}
       volumes:
         - name: "config"
           configMap:

--- a/charts/gafaelfawr/templates/post-install-tokens.yaml
+++ b/charts/gafaelfawr/templates/post-install-tokens.yaml
@@ -27,6 +27,25 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
       containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+        {{- end }}
         - name: "gafaelfawr"
           securityContext:
             allowPrivilegeEscalation: false
@@ -56,25 +75,6 @@ spec:
             - name: "secret"
               mountPath: "/etc/gafaelfawr/secrets"
               readOnly: true
-        {{- if .Values.cloudsql.enabled }}
-        - name: "cloud-sql-proxy"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
-            readOnlyRootFilesystem: true
-          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
-          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
-          command:
-            - "/cloud_sql_proxy"
-            - "-ip_address_type=PRIVATE"
-            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
-        {{- end }}
       volumes:
         - name: "config"
           configMap:


### PR DESCRIPTION
Fix a typo in the command line flag specifying IP address types,
and put the Cloud SQL Auth Proxy container first since it has to
be running before Gafaelfawr can start.