### PR TITLE
[DM-28120] Fix syntax error in Gafaelfawr config map

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 3.0.4
+version: 3.0.5
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -107,6 +107,7 @@ data:
           secret_namespace: {{ $secret.secretNamespace | quote }}
           service: {{ $secret.service | quote }}
           {{- if $secret.scopes }}
+          scopes:
             {{- range $scope := $secret.scopes }}
             - {{ $scope | quote }}
             {{- end }}


### PR DESCRIPTION
Was missing the scopes key when configuring Kubernetes secrets to
create.