### PR TITLE
[DM-28120] Add TLS support to the landing-page chart

### DIFF
--- a/charts/landing-page/Chart.yaml
+++ b/charts/landing-page/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: Simple landing page for linking to services, and showing MOTD.
 name: landing-page
-version: 0.2.4
+version: 0.3.0
 home: https://github.com/lsst-dm/lsp-landing-page
 maintainers:
   - name: cbanek

--- a/charts/landing-page/templates/ingress.yaml
+++ b/charts/landing-page/templates/ingress.yaml
@@ -1,11 +1,25 @@
 kind: Ingress
 apiVersion: networking.k8s.io/v1beta1
 metadata:
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ template "landing-page.fullname" . }}
   labels:
     app: {{ template "landing-page.fullname" . }}
     chart: {{ template "landing-page.chart" . }}
 spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
 {{ if .Values.host }}
   - host: {{ .Values.host }}

--- a/charts/landing-page/values.yaml
+++ b/charts/landing-page/values.yaml
@@ -4,6 +4,14 @@
 
 replicaCount: 1
 
+ingress:
+  # -- Additional annotations to add to the ingress
+  annotations: {}
+
+  # -- Configures TLS for the ingress if needed. If multiple ingresses share
+  # the same hostname, only one of them needs a TLS configuration.
+  tls: []
+
 # This is a link to a markdown file containing the message of the day.
 # Point this at a URL containing messages you want to show to the users.
 motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/Readme.md


### PR DESCRIPTION
This is temporary since it will soon be replaced by squareone, but
we need some ingress to take over the TLS configuration from
nublado, and this is the logical choice.

Also require Helm 3, since we're already using that.