### PR TITLE
[DM-28120] Add support for a Gafaelfawr db to postgres

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: Postgres RDBMS for LSP
 home: https://hub.docker.com/r/lsstsqre/lsp-postgres
 maintainers:
   - name: athornton
 name: postgres
-version: 0.0.27
+version: 0.1.0

--- a/charts/postgres/templates/deployment.yml
+++ b/charts/postgres/templates/deployment.yml
@@ -65,6 +65,17 @@ spec:
                 name: postgres
                 key: exposurelog_password
           {{- end }}
+          {{- with .Values.gafaelfawr_db }}
+          - name: VRO_DB_GAFAELFAWR_USER
+            value: {{ .user }}
+          - name: VRO_DB_GAFAELFAWR_DB
+            value: {{ .db }}
+          - name: VRO_DB_GAFAELFAWR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: postgres
+                key: gafaelfawr_password
+          {{- end }}
       {{- if .Values.pull_secret }}
       imagePullSecrets:
       - name: {{ .Values.pull_secret }}


### PR DESCRIPTION
Currently each database needs a configuration stanza in the postgres
chart.  Add support for a Gafaelfawr database, which we'll use in
the environments without CloudSQL.