### PR TITLE
[DM-29799] Don't create a pvc for users

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nublado2
-version: 0.1.4
+version: 0.1.5
 appVersion: 1.1.3
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -110,6 +110,7 @@ jupyterhub:
           mountPath: /etc/gshadow
           readOnly: true
           subPath: gshadow
+      type: none
 
   auth:
     type: custom


### PR DESCRIPTION
I think when we refactored the list of volumes, the normal list of
volumes included a claim.  This prevents the startup.  We were still
doing it wrong before, but since we didn't try to mount the unbound
PVC we got under the radar.