### PR TITLE
[DM-28120] Bump appVersion of squareone

### DIFF
--- a/charts/squareone/Chart.yaml
+++ b/charts/squareone/Chart.yaml
@@ -9,13 +9,15 @@ maintainers:
   - name: jonathansick
     url: https://github.com/jonathansick
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+# This is the chart version. This version number should be incremented each
+# time you make changes to the chart and its templates, including the app
+# version.  Versions are expected to follow Semantic Versioning
+# (https://semver.org/)
+version: 0.1.3
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "0.1.0"
+# This is the version number of the application being deployed. This version
+# number should be incremented each time you make changes to the
+# application. Versions are not expected to follow Semantic Versioning. They
+# should reflect the version the application is using.  It is recommended to
+# use it with quotes.
+appVersion: "0.1.3"


### PR DESCRIPTION
Change the default version deployed by squareone to 0.1.3, the
latest release.