### PR TITLE
[DM-28120] Fix Gafaelfawr ingress templating

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 3.0.13
+version: 3.0.14
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/ingress-rewrite.yaml
+++ b/charts/gafaelfawr/templates/ingress-rewrite.yaml
@@ -23,7 +23,7 @@ spec:
     {{- else }}
     - http:
     {{- end }}
-        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
         paths:
           - path: "/auth/tokens/id/.*"
             pathType: Prefix

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
     {{- else }}
     - http:
     {{- end }}
-        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
         paths:
           - path: "/auth"
             pathType: Prefix


### PR DESCRIPTION
Too much whitespace was being removed in the Kubernetes 1.19 case,
which caused construction of an invalid field.