### PR TITLE
[DM-28120] Fix Gafaelfawr ingress detection

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 3.0.15
+version: 3.0.16
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/ingress-rewrite.yaml
+++ b/charts/gafaelfawr/templates/ingress-rewrite.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -23,7 +23,7 @@ spec:
     {{- else }}
     - http:
     {{- end }}
-        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
         paths:
           - path: "/auth/tokens/id/.*"
             pathType: Prefix

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -21,7 +21,7 @@ spec:
     {{- else }}
     - http:
     {{- end }}
-        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
         paths:
           - path: "/auth"
             pathType: Prefix


### PR DESCRIPTION
Use .Capabilities.APIVersion.Has instead of semverCompare, since
the latter apparently didn't work correctly for Kubernetes 1.18.