### PR TITLE
[DM-28120] Revert to networking.k8s.io/v1beta1

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 3.0.16
+version: 3.0.17
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/ingress-rewrite.yaml
+++ b/charts/gafaelfawr/templates/ingress-rewrite.yaml
@@ -1,3 +1,8 @@
+{{- /*
+  Revert c8641fd03f71762b252bab10aacd932acfb5298a when Argo CD has been
+  fixed to pass in cluster capabilities, or when all clusters are running
+  Kubernetes 1.19 or later.
+*/ -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:

--- a/charts/gafaelfawr/templates/ingress-rewrite.yaml
+++ b/charts/gafaelfawr/templates/ingress-rewrite.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -23,7 +23,7 @@ spec:
     {{- else }}
     - http:
     {{- end }}
-        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
         paths:
           - path: "/auth/tokens/id/.*"
             pathType: Prefix

--- a/charts/gafaelfawr/templates/ingress-rewrite.yaml
+++ b/charts/gafaelfawr/templates/ingress-rewrite.yaml
@@ -1,8 +1,4 @@
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else -}}
 apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   annotations:
@@ -23,19 +19,8 @@ spec:
     {{- else }}
     - http:
     {{- end }}
-        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
-        paths:
-          - path: "/auth/tokens/id/.*"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ template "gafaelfawr.fullname" . }}
-                port:
-                  number: 8080
-        {{- else }}
         paths:
           - path: "/auth/tokens/id/.*"
             backend:
               serviceName: {{ template "gafaelfawr.fullname" . }}
               servicePort: 8080
-        {{- end }}

--- a/charts/gafaelfawr/templates/ingress-rewrite.yaml
+++ b/charts/gafaelfawr/templates/ingress-rewrite.yaml
@@ -1,5 +1,5 @@
 {{- /*
-  Revert c8641fd03f71762b252bab10aacd932acfb5298a when Argo CD has been
+  Revert 3d0f5a89831d5c05f8d384031df6074fb6287e67 when Argo CD has been
   fixed to pass in cluster capabilities, or when all clusters are running
   Kubernetes 1.19 or later.
 */ -}}

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -1,3 +1,8 @@
+{{- /*
+  Revert c8641fd03f71762b252bab10aacd932acfb5298a when Argo CD has been
+  fixed to pass in cluster capabilities, or when all clusters are running
+  Kubernetes 1.19 or later.
+*/ -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-  Revert c8641fd03f71762b252bab10aacd932acfb5298a when Argo CD has been
+  Revert 3d0f5a89831d5c05f8d384031df6074fb6287e67 when Argo CD has been
   fixed to pass in cluster capabilities, or when all clusters are running
   Kubernetes 1.19 or later.
 */ -}}

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -1,8 +1,4 @@
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else -}}
 apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   annotations:
@@ -21,53 +17,6 @@ spec:
     {{- else }}
     - http:
     {{- end }}
-        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
-        paths:
-          - path: "/auth"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ template "gafaelfawr.fullname" . }}
-                port:
-                  number: 8080
-          - path: "/login"
-            pathType: Exact
-            backend:
-              service:
-                name: {{ template "gafaelfawr.fullname" . }}
-                port:
-                  number: 8080
-          - path: "/logout"
-            pathType: Exact
-            backend:
-              service:
-                name: {{ template "gafaelfawr.fullname" . }}
-                port:
-                  number: 8080
-          - path: "/oauth2/callback"
-            pathType: Exact
-            backend:
-              service:
-                name: {{ template "gafaelfawr.fullname" . }}
-                port:
-                  number: 8080
-          - path: "/.well-known/jwks.json"
-            pathType: Exact
-            backend:
-              service:
-                name: {{ template "gafaelfawr.fullname" . }}
-                port:
-                  number: 8080
-          {{- if .Values.config.oidcServer.enabled }}
-          - path: "/.well-known/openid-configuration"
-            pathType: Exact
-            backend:
-              service:
-                name: {{ template "gafaelfawr.fullname" . }}
-                port:
-                  number: 8080
-          {{- end }}
-        {{- else }}
         paths:
           - path: "/auth"
             backend:
@@ -95,7 +44,6 @@ spec:
               serviceName: {{ template "gafaelfawr.fullname" . }}
               servicePort: 8080
           {{- end }}
-        {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -21,7 +21,7 @@ spec:
     {{- else }}
     - http:
     {{- end }}
-        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+        {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
         paths:
           - path: "/auth"
             pathType: Prefix


### PR DESCRIPTION
Argo CD isn't correctly passing data to Helm to execute the
conditional, so temporarily revert to always using the
networking.k8s.io/v1beta1 API version.  This can be reverted when
Argo CD has been upgraded to correctly tell Helm about cluster
capabilities, or once all clusters have been upgraded to
Kubernetes 1.19 or later.
