### PR TITLE
[DM-28120] Support a NetworkPolicy for Gafaelfawr

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 3.0.17
+version: 3.1.0
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/README.md
+++ b/charts/gafaelfawr/README.md
@@ -1,6 +1,6 @@
 # gafaelfawr
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 3.0.16](https://img.shields.io/badge/Version-3.0.16-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 The Gafaelfawr authentication and authorization system
 
@@ -20,13 +20,14 @@ The Gafaelfawr authentication and authorization system
 | cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases on Google Cloud |
 | cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
 | cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
-| cloudsql.image.tag | string | `"1.21.0"` | Cloud SQL Auth Proxy tag to use |
+| cloudsql.image.tag | string | `"1.22.0-buster"` | Cloud SQL Auth Proxy tag to use |
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a CloudSQL PostgreSQL instance |
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `gafaelfawr` and `gafaelfawr-tokens` Kubernetes service accounts and has the `cloudsql.client` role |
 | config.cilogon.clientId | string | `""` | CILogon client ID. One and only one of this or config.github.clientId must be set. |
 | config.cilogon.loginParams | object | `{"skin":"LSST"}` | Additional parameters to add |
 | config.cilogon.redirectUrl | string | `/login` at the value of config.host | Return URL given to CILogon (must match the CILogon configuration) |
 | config.cilogon.test | bool | `false` | Whether to use the test instance of CILogon |
+| config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.github.clientId | string | `""` | GitHub client ID. One and only one of this or config.cilogon.clientId must be set. |
 | config.groupMapping | object | `{}` | Defines a mapping of scopes to groups that provide that scope. Tokens from an OpenID Connect provider such as CILogon that include groups in an `isMemberOf` claim will be granted scopes based on this mapping. |
 | config.host | string | None, must be set | Used to construct issuers and URLs. |
@@ -48,6 +49,7 @@ The Gafaelfawr authentication and authorization system
 | ingress.host | string | `""` | Hostname for the ingress. This should normally be the same as config.host. |
 | ingress.tls | list | `[]` | Configures TLS for the ingress if needed. If multiple ingresses share the same hostname, only one of them needs a TLS configuration. |
 | nameOverride | string | `""` | Override the base name for resources |
+| networkPolicy.enabled | bool | `false` | Whether to restrict access to the Gafaelfawr service. Only enable if the ingress controller namespace is tagged with `gafaelfawr.lsst.io/ingress: "true"`. |
 | nodeSelector | object | `{}` | Node selector rules for the Gafaelfawr frontend pod |
 | podAnnotations | object | `{}` | Annotations for the Gafaelfawr frontend pod |
 | redis.affinity | object | `{}` | Affinity rules for the Redis pod |

--- a/charts/gafaelfawr/templates/networkpolicy.yaml
+++ b/charts/gafaelfawr/templates/networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "gafaelfawr.fullname" . }}
+  labels:
+    {{- include "gafaelfawr.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound access to the frontend component.
+    matchLabels:
+      {{- include "gafaelfawr.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "frontend"
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access to Redis from any pods in a namespace tagged with
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080
+{{- end }}

--- a/charts/gafaelfawr/templates/networkpolicy.yaml
+++ b/charts/gafaelfawr/templates/networkpolicy.yaml
@@ -14,10 +14,11 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # Allow inbound access to Redis from any pods in a namespace tagged with
+    # Allow inbound access to Redis from pods (in any namespace) labeled
     # gafaelfawr.lsst.io/ingress: true.
     - from:
-        - namespaceSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
               gafaelfawr.lsst.io/ingress: "true"
       ports:

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -52,6 +52,12 @@ ingress:
   # the same hostname, only one of them needs a TLS configuration.
   tls: []
 
+networkPolicy:
+  # -- Whether to restrict access to the Gafaelfawr service. Only enable if
+  # the ingress controller namespace is tagged with
+  # `gafaelfawr.lsst.io/ingress: "true"`.
+  enabled: false
+
 # -- Resource limits and requests for the Gafaelfawr frontend pod
 resources: {}
 


### PR DESCRIPTION
If enabled, this will restrict access to the Gafaelfawr pod to only
pods in a namespace tagged with gafaelfawr.lsst.io/ingress with a
value of "true".  This will require all cluster access go through
the ingress and will allow hiding of routes by not creating an ingress
for them (the plan is to use this for /auth to prevent users from
minting arbitrary internal and notebook tickets).