### PR TITLE
[DM-28120] Update firefly chart to SUIT 2.2.0

### DIFF
--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
-appVersion: "1.0"
-description: A Helm chart for Firefly
+apiVersion: v2
+appVersion: "2.2.0"
+description: "SUIT: the Rubin Science Platform portal aspect"
 name: firefly
-home: https://github.com/Caltech-IPAC/firefly
+home: "https://github.com/lsst/suit"
 maintainers:
   - name: cbanek
-version: 0.2.1
+version: 0.3.0

--- a/charts/firefly/templates/deployment.yaml
+++ b/charts/firefly/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
       - name: firefly
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/charts/firefly/values.yaml
+++ b/charts/firefly/values.yaml
@@ -4,8 +4,7 @@
 
 image:
   repository: ipac/suit
-  tag: lsst-stable
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 max_jvm_size: "2G"
 replicaCount: 1


### PR DESCRIPTION
Change appVersion to 2.2.0 and set the default image tag to the
appVersion rather than hard-coding it in values.yaml.  Switch the
chart to Helm v3 (which we're already using to install it in
Science Platform environments).

This chart should be renamed to suit or portal, but that will be
done later as part of a larger overhaul.