### PR TITLE
[DM-30007] Rework lab environment creation

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nublado2
-version: 0.1.8
-appVersion: 1.1.4
+version: 0.2.0
+appVersion: 1.2.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2
 maintainers:

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -186,6 +186,31 @@ config:
   volumes: []
   volume_mounts: []
 
+  # -- Environment variables to set in spanwed lab containers. Each value will
+  # be expanded using Jinja 2 templating.
+  # @default -- See `values.yaml`
+  lab_environment:
+    EXTERNAL_INSTANCE_URL: "{{ base_url }}"
+    FIREFLY_ROUTE: /portal/app
+    HUB_ROUTE: "{{ nublado_base_url }}"
+    JS9_ROUTE: /js9
+    API_ROUTE: /api
+    TAP_ROUTE: /api/tap
+    SODA_ROUTE: /api/image/soda
+    WORKFLOW_ROUTE: /wf
+    AUTO_REPO_URLS: https://github.com/lsst-sqre/notebook-demo
+    PGPASSFILE: /opt/lsst/software/jupyterlab/butler-secret/postgres-credentials.txt
+    AWS_SHARED_CREDENTIALS_FILE: /opt/lsst/software/jupyterlab/butler-secret/aws-credentials.ini
+    S3_ENDPOINT_URL: https://storage.googleapis.com
+    NO_SUDO: "TRUE"
+    EXTERNAL_GROUPS: "{{ external_groups }}"
+    EXTERNAL_UID: "{{ uid }}"
+    ACCESS_TOKEN: "{{ token }}"
+    IMAGE_DIGEST: "{{ options.image_info.digest }}"
+    IMAGE_DESCRIPTION: "{{ options.image_info.display_name }}"
+    CLEAR_DOTLOCAL: "{{ options.clear_dotlocal }}"
+    DEBUG: "{{ options.debug }}"
+
   # -- Templates for the user resources to create for each lab spawn. This is
   # a string that can be templated and then loaded as YAML to generate a list
   # of Kubernetes objects to create.
@@ -195,32 +220,6 @@ config:
       kind: Namespace
       metadata:
         name: "{{ user_namespace }}"
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: lab-environment
-        namespace: "{{ user_namespace }}"
-      data:
-        EXTERNAL_INSTANCE_URL: "{{ base_url }}"
-        FIREFLY_ROUTE: /portal/app
-        HUB_ROUTE: "{{ nublado_base_url }}"
-        JS9_ROUTE: /js9
-        API_ROUTE: /api
-        TAP_ROUTE: /api/tap
-        SODA_ROUTE: /api/image/soda
-        WORKFLOW_ROUTE: /wf
-        AUTO_REPO_URLS: https://github.com/lsst-sqre/notebook-demo
-        PGPASSFILE: /opt/lsst/software/jupyterlab/butler-secret/postgres-credentials.txt
-        AWS_SHARED_CREDENTIALS_FILE: /opt/lsst/software/jupyterlab/butler-secret/aws-credentials.ini
-        S3_ENDPOINT_URL: https://storage.googleapis.com
-        NO_SUDO: "TRUE"
-        EXTERNAL_GROUPS: "{{ external_groups }}"
-        EXTERNAL_UID: "{{ uid }}"
-        ACCESS_TOKEN: "{{ token }}"
-        IMAGE_DIGEST: "{{ options.image_info.digest }}"
-        IMAGE_DESCRIPTION: "{{ options.image_info.display_name }}"
-        CLEAR_DOTLOCAL: "{{ options.clear_dotlocal }}"
-        DEBUG: "{{ options.debug }}"
     - apiVersion: v1
       kind: ConfigMap
       metadata:

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -185,28 +185,21 @@ config:
       ram: 12288M
   volumes: []
   volume_mounts: []
+
+  # -- Templates for the user resources to create for each lab spawn. This is
+  # a string that can be templated and then loaded as YAML to generate a list
+  # of Kubernetes objects to create.
+  # @default -- See `values.yaml`
   user_resources_template: |
     - apiVersion: v1
       kind: Namespace
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: lab-environment
         namespace: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
       data:
         EXTERNAL_INSTANCE_URL: "{{ base_url }}"
         FIREFLY_ROUTE: /portal/app
@@ -231,14 +224,8 @@ config:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: group
         namespace: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
       data:
         group: |
           root:x:0:
@@ -283,14 +270,8 @@ config:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: gshadow
         namespace: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
       data:
         gshadow: |
           root:!::
@@ -335,14 +316,8 @@ config:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: passwd
         namespace: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
       data:
         passwd: |
           root:x:0:0:root:/root:/bin/bash
@@ -367,14 +342,8 @@ config:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: shadow
         namespace: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
       data:
         shadow: |
           root:*:18000:0:99999:7:::
@@ -399,76 +368,43 @@ config:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: dask
         namespace: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
       data:
         dask_worker.yml: |
           {{ dask_yaml | indent(6) }}
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: "{{ user }}-serviceaccount"
         namespace: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: "{{ user }}-role"
         namespace: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
       rules:
-      - apiGroups: [""]
-        resources: ["pods"]
-        verbs: ["create", "get", "delete", "list"]
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["create", "get", "delete", "list"]
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
         name: "{{ user }}-rolebinding"
         namespace: "{{ user_namespace }}"
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: "{{ user }}-role"
       subjects:
-      - kind: ServiceAccount
-        name: "{{ user }}-serviceaccount"
-        namespace: "{{ user_namespace }}"
-  # CRDs must be created with a separate API, so they need to
-  #  be in their own section.
-  custom_resources_template: |
+        - kind: ServiceAccount
+          name: "{{ user }}-serviceaccount"
+          namespace: "{{ user_namespace }}"
     - apiVersion: ricoberger.de/v1alpha1
       kind: VaultSecret
       metadata:
         name: butler-secret
         namespace: "{{ user_namespace }}"
-        annotations:
-          {% for k, v in annotations.items() %}{{ k }}: {{ v }}
-          {% endfor %}
-        labels:
-          {% for k, v in labels.items() %}{{ k }}: {{ v }}
-          {% endfor %}
       spec:
         path: "{{ butler_secret_path }}"
         type: Opaque


### PR DESCRIPTION
Rather than making the user resource templates a long quoted string,
keep them as YAML.  This allows overriding pieces of the template
from Phalanx, such as the environment variables.

Remove the templating for labels and annotations since it's identical
for every resource and every Kubernetes resource supports labels and
annotations, so they can be added directly in the nublado2 code.

Merge custom resources back in with core resources since nublado2 will
be able to handle this.