### PR TITLE
Mount volume for .next/cache/images

### DIFF
--- a/charts/squareone/Chart.yaml
+++ b/charts/squareone/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # time you make changes to the chart and its templates, including the app
 # version.  Versions are expected to follow Semantic Versioning
 # (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the

--- a/charts/squareone/templates/deployment.yaml
+++ b/charts/squareone/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
           volumeMounts:
             - name: "config"
               mountPath: "/etc/squareone"
+            - name: "next-image-cache"
+              mountPath: "/app/.next/cache/images"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -70,3 +72,5 @@ spec:
         - name: "config"
           configMap:
             name: {{ include "squareone.fullname" . }}
+        - name: "next-image-cache"
+          emptyDir: {}


### PR DESCRIPTION
During runtime, the next/image component creates cached versions of
image variants that the app serves. These are stored
in /.next/cache/images. Since we run squareone in a read-only filesystem
for security, the next app isn't able to create and write to this
directory. A solution is to mount an emptyDir at that path. This change
involves an update to the squareone Helm chart.