### PR TITLE
squareone chart 0.1.6, app 0.1.5

### DIFF
--- a/charts/squareone/Chart.yaml
+++ b/charts/squareone/Chart.yaml
@@ -13,11 +13,11 @@ maintainers:
 # time you make changes to the chart and its templates, including the app
 # version.  Versions are expected to follow Semantic Versioning
 # (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the
 # application. Versions are not expected to follow Semantic Versioning. They
 # should reflect the version the application is using.  It is recommended to
 # use it with quotes.
-appVersion: "0.1.4"
+appVersion: "0.1.5"


### PR DESCRIPTION
This app update includes the ops-era funding text and images.