### PR TITLE
[DM-30007] Remove Butler environment variables from nublado2

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nublado2
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.2.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -199,9 +199,6 @@ config:
     SODA_ROUTE: /api/image/soda
     WORKFLOW_ROUTE: /wf
     AUTO_REPO_URLS: https://github.com/lsst-sqre/notebook-demo
-    PGPASSFILE: /opt/lsst/software/jupyterlab/butler-secret/postgres-credentials.txt
-    AWS_SHARED_CREDENTIALS_FILE: /opt/lsst/software/jupyterlab/butler-secret/aws-credentials.ini
-    S3_ENDPOINT_URL: https://storage.googleapis.com
     NO_SUDO: "TRUE"
     EXTERNAL_GROUPS: "{{ external_groups }}"
     EXTERNAL_UID: "{{ uid }}"


### PR DESCRIPTION
These environment variables are per-environment and should only be
set on the IDF, so remove them from the chart.  They will be added
by Phalanx.