### PR TITLE
[DM-30007] Bump nublado2 container version

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nublado2
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.2.0
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -6,7 +6,7 @@ jupyterhub:
   hub:
     image:
       name: lsstsqre/nublado2
-      tag: "1.1.4"
+      tag: "1.2.0"
     containerSecurityContext:
       runAsUser: 768
       runAsGroup: 768


### PR DESCRIPTION
This chart can't use appVersion because it's configuring a subchart.
Bump the container version in the correct place.