### PR TITLE
[DM-30096] Nublado2 use postgres database

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nublado2
-version: 0.2.3
-appVersion: 1.2.1
+version: 0.2.4
+appVersion: 1.2.2
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2
 maintainers:

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -6,7 +6,12 @@ jupyterhub:
   hub:
     image:
       name: lsstsqre/nublado2
-      tag: "1.2.1"
+      tag: "1.2.2"
+    db:
+      # Password comes from the nublado2-secret.
+      type: "postgres"
+      password: "true"
+      url: "postgresql://jovyan@postgres.postgres/jupyterhub"
     containerSecurityContext:
       runAsUser: 768
       runAsGroup: 768


### PR DESCRIPTION
Use the internal postgres database.  The password comes from
the nublado2 secret and is injected as an environment variable,
and used with the connection string.  This way we don't have to
have the password in the connection string.