### PR TITLE
DM-30036: exposurelog: update port and probe URLs

### DIFF
--- a/charts/exposurelog/Chart.yaml
+++ b/charts/exposurelog/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.21
+version: 0.1.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/exposurelog/templates/deployment.yaml
+++ b/charts/exposurelog/templates/deployment.yaml
@@ -39,15 +39,15 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /exposurelog?query=%7B__schema%7BqueryType%7Bname%7D%7D%7D
+              path: /exposurelog
               port: http
           readinessProbe:
             httpGet:
-              path: /exposurelog?query=%7B__schema%7BqueryType%7Bname%7D%7D%7D
+              path: /exposurelog
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/exposurelog/values.yaml
+++ b/charts/exposurelog/values.yaml
@@ -53,7 +53,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 80
 
 ingress:
   enabled: false


### PR DESCRIPTION
I forgot to update the port # and probe URLs. For the latter I think it suffices to use /exposurelog; I tested this by making startup take essentially forever, and by making it fail, and in both cases the URL did not return. However, for the record, one can get the schema using exposurelog/openapi.json (thought I have not been able to find official documentation saying that).