### PR TITLE
[DM-30180] Cachemachine mount pod info

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -3,5 +3,5 @@ description: A Helm chart for Kubernetes
 name: cachemachine
 maintainers:
   - name: cbanek
-version: 0.1.9
-appVersion: 1.0.8
+version: 0.1.10
+appVersion: 1.0.9

--- a/charts/cachemachine/templates/deployment.yaml
+++ b/charts/cachemachine/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
           - name: autostart
             mountPath: "/etc/cachemachine"
             readOnly: true
+          - name: podinfo
+            mountPath: /etc/podinfo
       volumes:
       {{- if .Values.docker_secret_name }}
       - name: docker-creds
@@ -66,6 +68,15 @@ spec:
       - name: autostart
         configMap:
           name: {{ include "cachemachine.fullname" . }}-autostart
+      - name: podinfo
+        downwardAPI:
+          items:
+            - path: "labels"
+              fieldRef:
+                fieldPath: metadata.labels
+            - path: "annotations"
+              fieldRef:
+                fieldPath: metadata.annotations
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cachemachine/templates/deployment.yaml
+++ b/charts/cachemachine/templates/deployment.yaml
@@ -71,12 +71,18 @@ spec:
       - name: podinfo
         downwardAPI:
           items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
             - path: "annotations"
               fieldRef:
                 fieldPath: metadata.annotations
+            - path: "labels"
+              fieldRef:
+                fieldPath: metadata.labels
+            - path: "name"
+              fieldRef:
+                fieldPath: metadata.name
+            - path: "uid"
+              fieldRef:
+                fieldPath: metadata.uid
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This allows cachemachine to have access to the labels and annotations
of the pod, which are set by other layers like argocd and helm.