### PR TITLE
[DM-29365] Fix YAML syntax error in Gafaelfawr chart

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.0.0
+version: 4.0.1
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/deployment-tokens.yaml
+++ b/charts/gafaelfawr/templates/deployment-tokens.yaml
@@ -43,6 +43,7 @@ spec:
             runAsGroup: 65532
           image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
           imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          command:
             - "/cloud_sql_proxy"
             - "-ip_address_types=PRIVATE"
             - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"


### PR DESCRIPTION
The CloudSQL support for the token Kubernetes controller was
missing the command: key, and helm lint didn't catch it.