### PR TITLE
[DM-29365] Fix Gafaelfawr token service account creation

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.0.1
+version: 4.0.2
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/README.md
+++ b/charts/gafaelfawr/README.md
@@ -1,6 +1,6 @@
 # gafaelfawr
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 The Gafaelfawr authentication and authorization system
 

--- a/charts/gafaelfawr/templates/serviceaccount-tokens.yaml
+++ b/charts/gafaelfawr/templates/serviceaccount-tokens.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tokens.serviceAccount.create .Values.tokens.secrets -}}
+{{- if .Values.tokens.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
The conditional for whether to create the token management service
account was incorrect.  Remove the obsolete config conditional.