### PR TITLE
[DM-29365] Grant Gafaelfawr access to service token status

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.0.2
+version: 4.0.3
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/serviceaccount-tokens.yaml
+++ b/charts/gafaelfawr/templates/serviceaccount-tokens.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["secrets"]
     verbs: ["create", "get", "patch", "update"]
   - apiGroups: ["gafaelfawr.lsst.io"]
-    resources: ["gafaelfawrservicetokens"]
+    resources: ["gafaelfawrservicetokens", "gafaelfawrservicetokens/status"]
     verbs: ["get", "list", "patch", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Apparently when status is a subresource, it gets separate RBAC
permissions.  Add it to the ClusterRole.  Don't worry about being
very precise about what permissions are required for the parent
resource and what permissions are required for the status
subresource; it doesn't seem worth it.