### PR TITLE
[DM-30064] Update Gafaelfawr URL for nublado2

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nublado2
-version: 0.3.3
-appVersion: 1.2.3
+version: 0.3.4
+appVersion: "1.2.3"
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2
 maintainers:
@@ -9,7 +9,7 @@ maintainers:
 sources:
   - https://github.com/lsst-sqre/nublado2
   - https://github.com/lsst-sqre/charts
-kubeVersion: '>=1.16.0-0'
+kubeVersion: ">=1.16.0-0"
 dependencies:
   - name: jupyterhub
     version: "0.9.0-n409.hce116620"

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -154,7 +154,7 @@ jupyterhub:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Token"
-      nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true"
+      nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         error_page 403 = "/auth/forbidden?scope=exec:notebook";
 


### PR DESCRIPTION
Use gafaelfawr.gafaelfawr instead of gafaelfawr-service.gafaelfawr
so that eventually we can retire the latter.