### PR TITLE
[DM-30456] Add ability to deploy multiple influxdb-sink connectors in kafka-connect-manager

### DIFF
--- a/charts/kafka-connect-manager/Chart.yaml
+++ b/charts/kafka-connect-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-connect-manager
-version: 0.9.0
+version: 0.9.1
 description: A Helm chart to deploy kafka connectors
 keywords:
   - Kafka, InfluxDB, S3, JDBC Sink, MirrorMaker 2

--- a/charts/kafka-connect-manager/README.md
+++ b/charts/kafka-connect-manager/README.md
@@ -1,6 +1,6 @@
 # kafka-connect-manager
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 A Helm chart to deploy kafka connectors
 
@@ -25,21 +25,22 @@ A Helm chart to deploy kafka connectors
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"lsstsqre/kafkaconnect"` |  |
 | image.tag | string | `"0.9.0"` |  |
-| influxdbSink.autoUpdate | bool | `true` | If autoUpdate is enabled, check for new kafka topics and add them to the connector dynamically. |
-| influxdbSink.checkInterval | string | `"15000"` | The interval, in milliseconds, to check for new topics and update the connector. |
-| influxdbSink.connectInfluxDb | string | `""` | InfluxDB database to write to. |
-| influxdbSink.connectInfluxErrorPolicy | string | `"THROW"` | Error policy. |
-| influxdbSink.connectInfluxMaxRetries | string | `"10"` | The maximum number of times a message is retried. |
-| influxdbSink.connectInfluxRetryInterval | string | `"60000"` | The interval, in milliseconds, between retries. Only valid when the connectInfluxErrorPolicy is set to `RETRY`. |
-| influxdbSink.connectInfluxUrl | string | `"http://localhost:8086"` | InfluxDB URL, can be internal to the cluster. |
-| influxdbSink.connectProgressEnabled | bool | `false` | Enables the output for how many records have been processed. |
-| influxdbSink.enabled | bool | `false` | Whether the InfluxDB Sink connector is deployed. |
-| influxdbSink.excludedTopics | string | `""` | Comma separated list of topics to exclude from selection. |
-| influxdbSink.influxSecret | string | `""` | InfluxDB credentials. |
-| influxdbSink.name | string | `"influxdb-sink"` | Name of the connector to create. |
-| influxdbSink.tasksMax | int | `1` | Number of Kafka Connect tasks. |
-| influxdbSink.timestamp | string | `"sys_time()"` | Timestamp to be used as the InfluxDB time, if not specified `sys_time()` is used. |
-| influxdbSink.topicRegex | string | `".*"` | Regex to filer topic names. |
+| influxdbSink.influxdb-sink | object | `{"autoUpdate":true,"checkInterval":"15000","connectInfluxDb":"","connectInfluxErrorPolicy":"THROW","connectInfluxMaxRetries":"10","connectInfluxRetryInterval":"60000","connectInfluxUrl":"http://localhost:8086","connectProgressEnabled":false,"enabled":false,"excludedTopicRegex":"","influxSecret":"","name":"influxdb-sink","tasksMax":1,"timestamp":"sys_time()","topicRegex":".*"}` | To create multiple instances of this connector repeat this block. The name of the instance, "influxdb-sink" in this case, is used as scope for the template variables. |
+| influxdbSink.influxdb-sink.autoUpdate | bool | `true` | If autoUpdate is enabled, check for new kafka topics. If they match topicRegex and excludedTopicRegex add them to the connector dynamically. |
+| influxdbSink.influxdb-sink.checkInterval | string | `"15000"` | The interval, in milliseconds, to check for new topics and update the connector. |
+| influxdbSink.influxdb-sink.connectInfluxDb | string | `""` | InfluxDB database to write to. |
+| influxdbSink.influxdb-sink.connectInfluxErrorPolicy | string | `"THROW"` | Error policy. |
+| influxdbSink.influxdb-sink.connectInfluxMaxRetries | string | `"10"` | The maximum number of times a message is retried. |
+| influxdbSink.influxdb-sink.connectInfluxRetryInterval | string | `"60000"` | The interval, in milliseconds, between retries. Only valid when the connectInfluxErrorPolicy is set to `RETRY`. |
+| influxdbSink.influxdb-sink.connectInfluxUrl | string | `"http://localhost:8086"` | InfluxDB URL, can be internal to the cluster. |
+| influxdbSink.influxdb-sink.connectProgressEnabled | bool | `false` | Enables the output for how many records have been processed. |
+| influxdbSink.influxdb-sink.enabled | bool | `false` | Whether this connector instance is deployed. |
+| influxdbSink.influxdb-sink.excludedTopicRegex | string | `""` | Regex to exclude topics from the list of selected topics from Kafka. |
+| influxdbSink.influxdb-sink.influxSecret | string | `""` | InfluxDB credentials. |
+| influxdbSink.influxdb-sink.name | string | `"influxdb-sink"` | Name of the connector instance to create. |
+| influxdbSink.influxdb-sink.tasksMax | int | `1` | Number of Kafka Connect tasks. |
+| influxdbSink.influxdb-sink.timestamp | string | `"sys_time()"` | Timestamp to be used as the InfluxDB time, if not specified `sys_time()` is used. |
+| influxdbSink.influxdb-sink.topicRegex | string | `".*"` | Regex to select topics from Kafka. |
 | jdbcSink.autoCreate | string | `"true"` | Whether to automatically create the destination table. |
 | jdbcSink.autoEvolve | string | `"false"` | Whether to automatically add columns in the table schema. |
 | jdbcSink.batchSize | string | `"3000"` | Specifies how many records to attempt to batch together for insertion into the destination table. |
@@ -65,11 +66,11 @@ A Helm chart to deploy kafka connectors
 | mirrorMaker2.targetClusterBootstrapServers | string | `"localhost:31090"` | Destination Kafka cluster. |
 | mirrorMaker2.tasksMax | int | `1` | Number of Kafka Connect tasks. |
 | mirrorMaker2.topicRegex | string | `".*"` | Regex for selecting topics. Comma-separated lists are also supported. |
-| s3Sink.autoUpdate | bool | `true` | Check for new topics and update the connector. |
+| s3Sink.autoUpdate | bool | `true` | If autoUpdate is enabled, check for new kafka topics. If they match topicRegex and excludedTopicRegex add them to the connector dynamically. |
 | s3Sink.awsSecret | string | `""` | Kubernetes secret with the `aws_access_key_id` and `aws_secret_access_key` secret keys. |
 | s3Sink.checkInterval | string | `"15000"` | The interval, in milliseconds, to check for new topics and update the connector. |
 | s3Sink.enabled | bool | `false` | Whether the Amazon S3 Sink connector is deployed. |
-| s3Sink.excludedTopics | string | `""` | Comma separated list of topics to exclude from selection. |
+| s3Sink.excludedTopicRegex | string | `""` | Regex to exclude topics from the list of selected topics from Kafka. |
 | s3Sink.flushSize | string | `"1000"` | Number of records written to store before invoking file commits. |
 | s3Sink.locale | string | `"en-US"` | The locale to use when partitioning with TimeBasedPartitioner. |
 | s3Sink.name | string | `"s3-sink"` | Name of the connector to create. |
@@ -82,7 +83,7 @@ A Helm chart to deploy kafka connectors
 | s3Sink.timestampExtractor | string | `"Record"` | The extractor determines how to obtain a timestamp from each record. |
 | s3Sink.timestampField | string | `"time"` | The record field to be used as timestamp by the timestamp extractor. Only applies if timestampExtractor is set to RecordField. |
 | s3Sink.timezone | string | `"UTC"` | The timezone to use when partitioning with TimeBasedPartitioner. |
-| s3Sink.topicRegex | string | `".*"` | Regex for selecting topics. |
+| s3Sink.topicRegex | string | `".*"` | Regex to select topics from Kafka. |
 | s3Sink.topicsDir | string | `"topics"` | Top level directory to store the data ingested from Kafka. |
 
 ----------------------------------------------

--- a/charts/kafka-connect-manager/templates/_helpers.tpl
+++ b/charts/kafka-connect-manager/templates/_helpers.tpl
@@ -3,17 +3,10 @@ Create chart name and version as used by the chart label.
 */}}
 
 {{- define "kafka-connect-manager.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "kafka-connect-manager.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "influxdb.user" -}}
-{{- printf "%s" .Values.influxdb.user | b64enc -}}
-{{- end }}
-
-{{- define "influxdb.password" -}}
-{{- printf "%s" .Values.influxdb.password | b64enc -}}
-{{- end -}}

--- a/charts/kafka-connect-manager/templates/influxdb_sink.yaml
+++ b/charts/kafka-connect-manager/templates/influxdb_sink.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kafka-connect-manager.name" . }}
+  name: {{ .Values.influxdbSink.name }}
   labels:
     helm.sh/chart: {{ include "kafka-connect-manager.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/kafka-connect-manager/templates/influxdb_sink.yaml
+++ b/charts/kafka-connect-manager/templates/influxdb_sink.yaml
@@ -1,71 +1,76 @@
-{{- if .Values.influxdbSink.enabled }}
+{{- range .Values.influxdbSink }}
+{{- with . }}
+{{- if .enabled }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.influxdbSink.name }}
+  name: {{ .name }}
   labels:
-    helm.sh/chart: {{ include "kafka-connect-manager.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ printf "%s-%s" $.Chart.Name $.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ include "kafka-connect-manager.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app: {{ printf "%s" $.Chart.Name | trunc 63 | trimSuffix "-" }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ include "kafka-connect-manager.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        app: {{ printf "%s" $.Chart.Name | trunc 63 | trimSuffix "-" }}
+        app.kubernetes.io/instance: {{ $.Release.Name }}
     spec:
       containers:
-      - name:  {{ include "kafka-connect-manager.name" . }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        imagePullPolicy:  {{ .Values.image.pullPolicy }}
+      - name:  "kafka-connect-manager"
+        image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
+        imagePullPolicy:  {{ $.Values.image.pullPolicy }}
         command:
         - kafkaconnect
         - create
         - influxdb-sink
-        {{- if .Values.influxdbSink.autoUpdate }}
+        {{- if .autoUpdate }}
         - --auto-update
         {{- end }}
         env:
           - name: KAFKA_CONNECT_NAME
-            value: {{ .Values.influxdbSink.name | quote }}
+            value: {{ .name | quote }}
           - name: KAFKA_CONNECT_INFLUXDB_URL
-            value: {{ .Values.influxdbSink.connectInfluxUrl | quote }}
+            value: {{ .connectInfluxUrl | quote }}
           - name: KAFKA_CONNECT_DATABASE
-            value: {{ .Values.influxdbSink.connectInfluxDb | quote }}
+            value: {{ .connectInfluxDb | quote }}
           - name: KAFKA_CONNECT_INFLUXDB_USERNAME
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.influxdbSink.influxSecret | quote }}
+                name: {{ .influxSecret | quote }}
                 key: influxdb-user
           - name: KAFKA_CONNECT_INFLUXDB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.influxdbSink.influxSecret | quote }}
+                name: {{ .influxSecret | quote }}
                 key: influxdb-password
           - name: KAFKA_CONNECT_TASKS_MAX
-            value: {{ .Values.influxdbSink.tasksMax | quote }}
+            value: {{ .tasksMax | quote }}
           - name: KAFKA_CONNECT_TOPIC_REGEX
-            value: {{ .Values.influxdbSink.topicRegex | quote }}
+            value: {{ .topicRegex | quote }}
           - name: KAFKA_CONNECT_CHECK_INTERVAL
-            value: {{ .Values.influxdbSink.checkInterval | quote  }}
+            value: {{ .checkInterval | quote  }}
           - name: KAFKA_CONNECT_EXCLUDED_TOPIC_REGEX
-            value: {{ .Values.influxdbSink.excludedTopicRegex | quote }}
+            value: {{ .excludedTopicRegex | quote }}
           - name: KAFKA_CONNECT_INFLUXDB_TIMESTAMP
-            value: {{ .Values.influxdbSink.timestamp | quote }}
+            value: {{ .timestamp | quote }}
           - name: KAFKA_CONNECT_ERROR_POLICY
-            value: {{ .Values.influxdbSink.connectInfluxErrorPolicy | quote }}
+            value: {{ .connectInfluxErrorPolicy | quote }}
           - name: KAFKA_CONNECT_MAX_RETRIES
-            value: {{ .Values.influxdbSink.connectInfluxMaxRetries | quote }}
+            value: {{ .connectInfluxMaxRetries | quote }}
           - name: KAFKA_CONNECT_RETRY_INTERVAL
-            value: {{ .Values.influxdbSink.connectInfluxRetryInterval | quote }}
+            value: {{ .connectInfluxRetryInterval | quote }}
           - name: KAFKA_CONNECT_PROGRESS_ENABLED
-            value: {{ .Values.influxdbSink.connectProgressEnabled | quote }}
+            value: {{ .connectProgressEnabled | quote }}
           - name: KAFKA_BROKER_URL
-            value: {{ .Values.env.kafkaBrokerUrl | quote }}
+            value: {{ $.Values.env.kafkaBrokerUrl | quote }}
           - name: KAFKA_CONNECT_URL
-            value: {{ .Values.env.kafkaConnectUrl | quote }}
+            value: {{ $.Values.env.kafkaConnectUrl | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kafka-connect-manager/templates/influxdb_sink.yaml
+++ b/charts/kafka-connect-manager/templates/influxdb_sink.yaml
@@ -52,8 +52,8 @@ spec:
             value: {{ .Values.influxdbSink.topicRegex | quote }}
           - name: KAFKA_CONNECT_CHECK_INTERVAL
             value: {{ .Values.influxdbSink.checkInterval | quote  }}
-          - name: KAFKA_CONNECT_EXCLUDED_TOPICS
-            value: {{ .Values.influxdbSink.excludedTopics | quote }}
+          - name: KAFKA_CONNECT_EXCLUDED_TOPIC_REGEX
+            value: {{ .Values.influxdbSink.excludedTopicRegex | quote }}
           - name: KAFKA_CONNECT_INFLUXDB_TIMESTAMP
             value: {{ .Values.influxdbSink.timestamp | quote }}
           - name: KAFKA_CONNECT_ERROR_POLICY

--- a/charts/kafka-connect-manager/templates/jdbc_sink.yaml
+++ b/charts/kafka-connect-manager/templates/jdbc_sink.yaml
@@ -27,7 +27,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kafka-connect-manager.name" . }}
+  name: {{ .Values.jdbcSink.name }}
   labels:
     helm.sh/chart: {{ include "kafka-connect-manager.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/kafka-connect-manager/templates/mirrormaker2.yaml
+++ b/charts/kafka-connect-manager/templates/mirrormaker2.yaml
@@ -45,7 +45,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kafka-connect-manager.name" . }}
+  name: {{ .Values.mirrorMaker2.name }}
   labels:
     helm.sh/chart: {{ include "kafka-connect-manager.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -85,7 +85,7 @@ spec:
         - name: mirrormaker2
           mountPath: /etc/mirrormaker2
       volumes:
-      - name: mirrormaker2 
+      - name: mirrormaker2
         configMap:
           name: mirrormaker2
 ---

--- a/charts/kafka-connect-manager/templates/s3_sink.yaml
+++ b/charts/kafka-connect-manager/templates/s3_sink.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kafka-connect-manager.name" . }}
+  name:  {{ .Values.s3Sink.name }}
   labels:
     helm.sh/chart: {{ include "kafka-connect-manager.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/kafka-connect-manager/templates/s3_sink.yaml
+++ b/charts/kafka-connect-manager/templates/s3_sink.yaml
@@ -62,8 +62,8 @@ spec:
             value: {{ .Values.s3Sink.topicRegex | quote }}
           - name: KAFKA_CONNECT_CHECK_INTERVAL
             value: {{ .Values.s3Sink.checkInterval | quote  }}
-          - name: KAFKA_CONNECT_EXCLUDED_TOPICS
-            value: {{ .Values.s3Sink.excludedTopics | quote }}
+          - name: KAFKA_CONNECT_EXCLUDED_TOPIC_REGEX
+            value: {{ .Values.s3Sink.excludedTopicRegex | quote }}
           - name: KAFKA_CONNECT_S3_LOCALE
             value: {{ .Values.s3Sink.locale | quote }}
           - name: KAFKA_CONNECT_S3_TIMEZONE

--- a/charts/kafka-connect-manager/values.yaml
+++ b/charts/kafka-connect-manager/values.yaml
@@ -7,36 +7,38 @@ image:
   pullPolicy: Always
 
 influxdbSink:
-  # -- Whether the InfluxDB Sink connector is deployed.
-  enabled: false
-  # -- Name of the connector to create.
-  name: influxdb-sink
-  # -- InfluxDB URL, can be internal to the cluster.
-  connectInfluxUrl: "http://localhost:8086"
-  # -- InfluxDB database to write to.
-  connectInfluxDb: ""
-  # -- InfluxDB credentials.
-  influxSecret: ""
-  # -- Number of Kafka Connect tasks.
-  tasksMax: 1
-  # -- Regex to select topics from Kafka.
-  topicRegex: ".*"
-  # -- If autoUpdate is enabled, check for new kafka topics. If they match topicRegex and excludedTopicRegex add them to the connector dynamically.
-  autoUpdate: true
-  # -- The interval, in milliseconds, to check for new topics and update the connector.
-  checkInterval: "15000"
-  # -- Regex to exclude topics from the list of selected topics from Kafka.
-  excludedTopicRegex: ""
-  # -- Timestamp to be used as the InfluxDB time, if not specified `sys_time()` is used.
-  timestamp: "sys_time()"
-  # -- Error policy.
-  connectInfluxErrorPolicy: THROW
-  # -- The maximum number of times a message is retried.
-  connectInfluxMaxRetries: "10"
-  # -- The interval, in milliseconds, between retries. Only valid when the connectInfluxErrorPolicy is set to `RETRY`.
-  connectInfluxRetryInterval: "60000"
-  # -- Enables the output for how many records have been processed.
-  connectProgressEnabled: false
+  # -- To create multiple instances of this connector repeat this block. The name of the instance, "influxdb-sink" in this case, is used as scope for the template variables.
+  influxdb-sink:
+    # -- Name of the connector instance to create.
+    name: influxdb-sink
+    # -- Whether this connector instance is deployed.
+    enabled: false
+    # -- InfluxDB URL, can be internal to the cluster.
+    connectInfluxUrl: "http://localhost:8086"
+    # -- InfluxDB database to write to.
+    connectInfluxDb: ""
+    # -- InfluxDB credentials.
+    influxSecret: ""
+    # -- Number of Kafka Connect tasks.
+    tasksMax: 1
+    # -- Regex to select topics from Kafka.
+    topicRegex: ".*"
+    # -- If autoUpdate is enabled, check for new kafka topics. If they match topicRegex and excludedTopicRegex add them to the connector dynamically.
+    autoUpdate: true
+    # -- The interval, in milliseconds, to check for new topics and update the connector.
+    checkInterval: "15000"
+    # -- Regex to exclude topics from the list of selected topics from Kafka.
+    excludedTopicRegex: ""
+    # -- Timestamp to be used as the InfluxDB time, if not specified `sys_time()` is used.
+    timestamp: "sys_time()"
+    # -- Error policy.
+    connectInfluxErrorPolicy: THROW
+    # -- The maximum number of times a message is retried.
+    connectInfluxMaxRetries: "10"
+    # -- The interval, in milliseconds, between retries. Only valid when the connectInfluxErrorPolicy is set to `RETRY`.
+    connectInfluxRetryInterval: "60000"
+    # -- Enables the output for how many records have been processed.
+    connectProgressEnabled: false
 
 s3Sink:
   # -- Whether the Amazon S3 Sink connector is deployed.

--- a/charts/kafka-connect-manager/values.yaml
+++ b/charts/kafka-connect-manager/values.yaml
@@ -19,14 +19,14 @@ influxdbSink:
   influxSecret: ""
   # -- Number of Kafka Connect tasks.
   tasksMax: 1
-  # -- Regex to filer topic names.
+  # -- Regex to select topics from Kafka.
   topicRegex: ".*"
-  # -- If autoUpdate is enabled, check for new kafka topics and add them to the connector dynamically.
+  # -- If autoUpdate is enabled, check for new kafka topics. If they match topicRegex and excludedTopicRegex add them to the connector dynamically.
   autoUpdate: true
   # -- The interval, in milliseconds, to check for new topics and update the connector.
   checkInterval: "15000"
-  # -- Comma separated list of topics to exclude from selection.
-  excludedTopics: ""
+  # -- Regex to exclude topics from the list of selected topics from Kafka.
+  excludedTopicRegex: ""
   # -- Timestamp to be used as the InfluxDB time, if not specified `sys_time()` is used.
   timestamp: "sys_time()"
   # -- Error policy.
@@ -61,14 +61,14 @@ s3Sink:
   pathFormat: "'year'=YYYY/'month'=MM/'day'=dd/'hour'=HH"
   # -- Number of Kafka Connect tasks.
   tasksMax: 1
-  # -- Regex for selecting topics.
+  # -- Regex to select topics from Kafka.
   topicRegex: ".*"
-  # -- Check for new topics and update the connector.
+  # -- If autoUpdate is enabled, check for new kafka topics. If they match topicRegex and excludedTopicRegex add them to the connector dynamically.
   autoUpdate: true
   # -- The interval, in milliseconds, to check for new topics and update the connector.
   checkInterval: "15000"
-  # -- Comma separated list of topics to exclude from selection.
-  excludedTopics: ""
+  # -- Regex to exclude topics from the list of selected topics from Kafka.
+  excludedTopicRegex: ""
   # -- The locale to use when partitioning with TimeBasedPartitioner.
   locale: "en-US"
   # -- The timezone to use when partitioning with TimeBasedPartitioner.


### PR DESCRIPTION
- Use regex to exclude topics
- Deploy multiple instances of the influxdb-sink connector