### PR TITLE
[DM-30369] Bump Gafaelfawr image versions

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.0.3
+version: 4.0.4
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:
   - name: rra
-appVersion: 3.0.0
+appVersion: 3.0.1

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -170,7 +170,7 @@ cloudsql:
     repository: "gcr.io/cloudsql-docker/gce-proxy"
 
     # -- Cloud SQL Auth Proxy tag to use
-    tag: "1.22.0-buster"
+    tag: "1.23.0-buster"
 
     # -- Pull policy for Cloud SQL Auth Proxy images
     pullPolicy: "IfNotPresent"
@@ -220,7 +220,7 @@ redis:
     repository: "redis"
 
     # -- Redis image tag to use
-    tag: "6.2.3"
+    tag: "6.2.4"
 
     # -- Pull policy for the Redis image
     pullPolicy: "IfNotPresent"


### PR DESCRIPTION
Install Gafaelfawr 3.0.1 and also bump the Google Cloud SQL Auth
Proxy and Redis container versions to their latest releases.