### PR TITLE
[DM-30789] Bump version of Gafaelfawr

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.0.5
+version: 4.0.6
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:
   - name: rra
-appVersion: 3.0.2
+appVersion: 3.0.3

--- a/charts/gafaelfawr/README.md
+++ b/charts/gafaelfawr/README.md
@@ -1,6 +1,6 @@
 # gafaelfawr
 
-![Version: 4.0.5](https://img.shields.io/badge/Version-4.0.5-informational?style=flat-square) ![AppVersion: 3.0.2](https://img.shields.io/badge/AppVersion-3.0.2-informational?style=flat-square)
+![Version: 4.0.6](https://img.shields.io/badge/Version-4.0.6-informational?style=flat-square) ![AppVersion: 3.0.3](https://img.shields.io/badge/AppVersion-3.0.3-informational?style=flat-square)
 
 The Gafaelfawr authentication and authorization system
 


### PR DESCRIPTION
Pick up 3.0.3, which has a fix for issuing of internal and
notebook tokens during race conditions.