### PR TITLE
[DM-30974] Add missing nginx-ingress annotation

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -3,5 +3,5 @@ description: A Helm chart for Kubernetes
 name: cachemachine
 maintainers:
   - name: cbanek
-version: 0.1.12
+version: 0.1.13
 appVersion: 1.0.12

--- a/charts/cachemachine/templates/ingress.yaml
+++ b/charts/cachemachine/templates/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ include "cachemachine.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    kubernetes.io/ingress.class: nginx
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/moneypenny/Chart.yaml
+++ b/charts/moneypenny/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 name: moneypenny
 maintainers:
   - name: athornton
-version: 0.0.3
+version: 0.0.4

--- a/charts/moneypenny/templates/ingress.yaml
+++ b/charts/moneypenny/templates/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ include "moneypenny.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    kubernetes.io/ingress.class: nginx
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/squareone/Chart.yaml
+++ b/charts/squareone/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # time you make changes to the chart and its templates, including the app
 # version.  Versions are expected to follow Semantic Versioning
 # (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the

--- a/charts/squareone/templates/ingress.yaml
+++ b/charts/squareone/templates/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- include "squareone.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    kubernetes.io/ingress.class: nginx
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
We think this was causing warning log lines in the logs, and
so by adding this annotation it should stop that.  For some reason,
it still works even without it.