### PR TITLE
DM-31034: Update for squareone 0.3.0

### DIFF
--- a/charts/squareone/Chart.yaml
+++ b/charts/squareone/Chart.yaml
@@ -13,11 +13,11 @@ maintainers:
 # time you make changes to the chart and its templates, including the app
 # version.  Versions are expected to follow Semantic Versioning
 # (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the
 # application. Versions are not expected to follow Semantic Versioning. They
 # should reflect the version the application is using.  It is recommended to
 # use it with quotes.
-appVersion: "0.2.2"
+appVersion: "0.3.0"

--- a/charts/squareone/templates/configmap.yaml
+++ b/charts/squareone/templates/configmap.yaml
@@ -10,3 +10,7 @@ data:
     baseUrl: https://{{ .Values.ingress.host | default "example.com" }}
     siteDescription: |
       {{ .Values.config.siteDescription }}
+    {{- if .Values.config.broadcastMarkdown }}
+    broadcastMarkdown: |
+      {{ .Values.config.broadcastMarkdown }}
+    {{- end}}

--- a/charts/squareone/values.yaml
+++ b/charts/squareone/values.yaml
@@ -85,3 +85,7 @@ config:
   # Site description, used in meta tags
   siteDescription: |
     Access Rubin Observatory Legacy Survey of Space and Time data.
+  # An optional broadcast notification for the banner. Format as
+  # GitHub-Flavored Markdown.
+  # broadcastMarkdown: |
+  #   Broadcast message.


### PR DESCRIPTION
In addition to updating to the version 0.3.0 squareone image, this chart update also includes the config.broadcastMarkdown key in the Helm values.

Includes a commented-out sample for making a broadcast message.