### PR TITLE
[DM-31018] Update to Gafaelfawr 3.2.0, add errorFooter

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.1.0
+version: 4.2.0
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:
   - name: rra
-appVersion: 3.1.0
+appVersion: 3.2.0

--- a/charts/gafaelfawr/README.md
+++ b/charts/gafaelfawr/README.md
@@ -1,6 +1,6 @@
 # gafaelfawr
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
 
 The Gafaelfawr authentication and authorization system
 
@@ -28,6 +28,7 @@ The Gafaelfawr authentication and authorization system
 | config.cilogon.redirectUrl | string | `/login` at the value of config.host | Return URL given to CILogon (must match the CILogon configuration) |
 | config.cilogon.test | bool | `false` | Whether to use the test instance of CILogon |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
+| config.errorFooter | string | `""` | HTML footer to add to any login error page (inside a <p> tag). |
 | config.github.clientId | string | `""` | GitHub client ID. One and only one of this or config.cilogon.clientId must be set. |
 | config.groupMapping | object | `{}` | Defines a mapping of scopes to groups that provide that scope. Tokens from an OpenID Connect provider such as CILogon that include groups in an `isMemberOf` claim will be granted scopes based on this mapping. |
 | config.host | string | None, must be set | Used to construct issuers and URLs. |

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -96,3 +96,7 @@ data:
       - {{ $admin | quote }}
       {{- end }}
     {{- end }}
+
+    {{- if .Values.config.errorFooter }}
+    error_footer: {{ .Values.config.errorFooter | quote }}
+    {{- end }}

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -160,6 +160,9 @@ config:
   # Used only if there are no administrators.
   initialAdmins: []
 
+  # -- HTML footer to add to any login error page (inside a <p> tag).
+  errorFooter: ""
+
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases
   # on Google Cloud


### PR DESCRIPTION
Update Gafaelfawr to the 3.2.0 release and add support for the new
config.errorFooter configuration parameter.