### PR TITLE
[DM-31082] Fix port of cachemachine service

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cachemachine
-version: 1.0.0
+version: 1.0.1
 description: Service to prepull Docker images for the Science Platform
 maintainers:
   - name: cbanek

--- a/charts/cachemachine/README.md
+++ b/charts/cachemachine/README.md
@@ -1,6 +1,6 @@
 # cachemachine
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.12](https://img.shields.io/badge/AppVersion-1.0.12-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 1.0.12](https://img.shields.io/badge/AppVersion-1.0.12-informational?style=flat-square)
 
 Service to prepull Docker images for the Science Platform
 

--- a/charts/cachemachine/templates/ingress.yaml
+++ b/charts/cachemachine/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
           - path: "/cachemachine"
             backend:
               serviceName: {{ template "cachemachine.fullname" . }}
-              servicePort: 8080
+              servicePort: 80
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/cachemachine/templates/service.yaml
+++ b/charts/cachemachine/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 8080
+    - port: 80
       targetPort: "http"
       protocol: "TCP"
   selector:


### PR DESCRIPTION
Go back to exposing port 80, since we have other references to
that port.