### PR TITLE
[DM-30073] Change Firefly default version to suit-233-7-dev

### DIFF
--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "2.2.0"
+appVersion: "suit-233-7-dev"
 description: "SUIT: the Rubin Science Platform portal aspect"
 name: firefly
 home: "https://github.com/lsst/suit"
 maintainers:
   - name: cbanek
-version: 0.3.1
+version: 0.3.2


### PR DESCRIPTION
This is what we're currently running on the IDF and Gregory confirms
it's what we should deploy everywhere for now until there's a new
full release.