### PR TITLE
[DM-31201] Convert mobu to a StatefulSet

### DIFF
--- a/charts/mobu/Chart.yaml
+++ b/charts/mobu/Chart.yaml
@@ -4,5 +4,5 @@ home: https://github.com/lsst-sqre/mobu
 maintainers:
   - name: cbanek
 name: mobu
-version: 1.0.0
+version: 1.1.0
 appVersion: 2.0.0

--- a/charts/mobu/templates/statefulset.yaml
+++ b/charts/mobu/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "mobu.fullname" . }}
   labels:
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "mobu.selectorLabels" . | nindent 6 }}
+  serviceName: "mobu"
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -22,11 +23,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      automountServiceAccountToken: false
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
We only want one mobu running at any given time or they stomp on
each other's labs and wreak havoc.  Convert the Deployment to a
StatefulSet so that the previous running mobu is always stopped
before the new mobu is started.