### PR TITLE
DM-30727: Create squareone 0.4.0-alpha.1

### DIFF
--- a/charts/squareone/Chart.yaml
+++ b/charts/squareone/Chart.yaml
@@ -13,11 +13,11 @@ maintainers:
 # time you make changes to the chart and its templates, including the app
 # version.  Versions are expected to follow Semantic Versioning
 # (https://semver.org/)
-version: 0.3.1
+version: 0.4.0-alpha.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the
 # application. Versions are not expected to follow Semantic Versioning. They
 # should reflect the version the application is using.  It is recommended to
 # use it with quotes.
-appVersion: "0.3.1"
+appVersion: "tickets-DM-30727"

--- a/charts/squareone/templates/configmap.yaml
+++ b/charts/squareone/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
     baseUrl: https://{{ .Values.ingress.host | default "example.com" }}
     siteDescription: |
       {{ .Values.config.siteDescription }}
-    {{- if .Values.config.broadcastMarkdown }}
-    broadcastMarkdown: |
-      {{ .Values.config.broadcastMarkdown }}
+    {{- if .Values.config.semaphoreUrl }}
+    semaphoreUrl: |
+      {{ .Values.config.semaphoreUrl }}
     {{- end}}

--- a/charts/squareone/values.yaml
+++ b/charts/squareone/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 
 image:
   repository: lsstsqre/squareone
-  pullPolicy: IfNotPresent
+  # pullPolicy: IfNotPresent
+  pullPolicy: Always  # FIXME remove before deployment
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
@@ -85,7 +86,4 @@ config:
   # Site description, used in meta tags
   siteDescription: |
     Access Rubin Observatory Legacy Survey of Space and Time data.
-  # An optional broadcast notification for the banner. Format as
-  # GitHub-Flavored Markdown.
-  # broadcastMarkdown: |
-  #   Broadcast message.
+  # semaphoreUrl: null


### PR DESCRIPTION
- Works with the tickets-DM-30727 image tag of squareone
- Remove broadcastMarkdown
- Add semaphoreUrl config