### PR TITLE
Update semaphore to 0.2.1

### DIFF
--- a/charts/semaphore/Chart.yaml
+++ b/charts/semaphore/Chart.yaml
@@ -12,10 +12,10 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.0"
+appVersion: "0.2.1"


### PR DESCRIPTION
This release fixes the `/v1/broadcasts` endpoint from showing messages that have `enabled: false` metadata.