### PR TITLE
[DM-31490] Bump version of mobu

### DIFF
--- a/charts/mobu/Chart.yaml
+++ b/charts/mobu/Chart.yaml
@@ -4,5 +4,5 @@ home: https://github.com/lsst-sqre/mobu
 maintainers:
   - name: cbanek
 name: mobu
-version: 2.0.0
-appVersion: 3.0.0
+version: 3.0.0
+appVersion: 4.0.0


### PR DESCRIPTION
Deploy the new version that supports testing the latest weekly and
integrates with cachemachine rather than requiring hard-coding the
form data for Jupyter spawning.