### PR TITLE
[DM-31529] Bump cachemachine version

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cachemachine
-version: 1.0.1
+version: 1.1.0
 description: Service to prepull Docker images for the Science Platform
 maintainers:
   - name: cbanek
-appVersion: 1.0.12
+appVersion: 1.1.0


### PR DESCRIPTION
Pick up fix to exclude cordoned nodes from the calculation of which
images are cached.