### PR TITLE
[DM-31490] Let mobu talk to cachemachine

### DIFF
--- a/charts/mobu/Chart.yaml
+++ b/charts/mobu/Chart.yaml
@@ -4,5 +4,5 @@ home: https://github.com/lsst-sqre/mobu
 maintainers:
   - name: cbanek
 name: mobu
-version: 3.0.0
-appVersion: 4.0.0
+version: 3.0.1
+appVersion: 4.0.1

--- a/charts/mobu/templates/gafaelfawr-token.yaml
+++ b/charts/mobu/templates/gafaelfawr-token.yaml
@@ -8,3 +8,4 @@ spec:
   service: "mobu"
   scopes:
     - "admin:token"
+    - "exec:admin"


### PR DESCRIPTION
Bump version of mobu so that it uses its own token and not the user
token for talking to cachemachine, and give it exec:admin scope so
that it will have access.  We can tighten this later, but mobu is
fairly safe to give enhanced permissions to (and admin:token is
already stronger than exec:admin).