### PR TITLE
[DM-31947] Remove old auth stanza, chart to 0.5.0

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nublado2
-version: 0.4.9
+version: 0.5.0
 appVersion: "1.4.0"
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -6,7 +6,7 @@ jupyterhub:
   hub:
     image:
       name: lsstsqre/nublado2
-      tag: "1.4.0"
+      tag: "1.4.1"
     config:
       Authenticator:
         enable_auth_state: true

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -127,13 +127,6 @@ jupyterhub:
           subPath: gshadow
       type: none
 
-  auth:
-    type: custom
-    custom:
-      className: nublado2.auth.GafaelfawrAuthenticator
-    state:
-      enabled: true
-
   proxy:
     chp:
       networkPolicy:


### PR DESCRIPTION
Okay so the issue seems to be while we added the new auth part,
we didn't take out the old auth part, which I think was tripping
over the deprecation warning in the helm chart, causing it to fail.

Since this is a pretty big change and a new version of jupyterhub,
let's just roll this to 0.5.0