### PR TITLE
tickets/DM-31959: pathSuffix lets "/nb" (no trailing slash) work again

### DIFF
--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nublado2
-version: 0.5.2
+version: 0.5.3
 appVersion: "1.4.1"
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -57,6 +57,8 @@ jupyterhub:
       enabled: false
 
   singleuser:
+    cloudMetadata:
+      blockWithIptables: false
     cmd: "/opt/lsst/software/jupyterlab/runlab.sh"
     defaultUrl: "/lab"
     extraAnnotations:
@@ -144,6 +146,7 @@ jupyterhub:
       nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook&notebook=true"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         error_page 403 = "/auth/forbidden?scope=exec:notebook";
+    pathSuffix: "*"
 
   # The default culler setting is enabled, with 3600s idle.  This is way
   #  too short for our purposes.  First cut: just disable it.


### PR DESCRIPTION
we do not want singleuser.cloudMetadata.blockWithIptables anywhere.