### PR TITLE
[DM-31965] Support datalink

### DIFF
--- a/charts/cadc-tap/Chart.yaml
+++ b/charts/cadc-tap/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.0.22"
+appVersion: "1.0.23"
 description: A Helm chart for the CADC TAP service
 home: https://github.com/lsst-sqre/lsst-tap-service
 maintainers:
   - name: cbanek
 name: cadc-tap
-version: 0.3.0
+version: 0.3.1

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -46,10 +46,13 @@ spec:
               -Dgafaelfawr_url=https://{{ .Values.host }}/auth/api/v1/user-info
               -Dgcs_bucket={{ .Values.gcs_bucket }}
               -Dgcs_bucket_url={{ .Values.gcs_bucket_url }}
+              -Dbase_url=https://{{ .Values.host }}
               -Dca.nrc.cadc.util.PropertiesReader.dir=/etc/creds/
               -Xmx{{ .Values.jvm_max_heap_size }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: "/etc/creds/google_creds.json"
+        - name: DATALINK_PAYLOAD_URL
+          value: "{{ .Values.datalink_payload_url }}"
       {{- if .Values.pull_secret }}
       imagePullSecrets:
       - name: {{ .Values.pull_secret }}

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -19,6 +19,9 @@ qserv_host: "qserv-master01:4040"
 # Address to a mysql database containing TAP schema data.
 tap_schema_address: "tap-schema-db.tap-schema.svc.cluster.local:3306"
 
+# Datalink payload URL
+datalink_payload_url: ""
+
 # Spin up a container to pretend to be QServ.
 use_mock_qserv: true
 


### PR DESCRIPTION
This will pass in the datalink package URL and the base URL to the
tap server, both of which are used to form the datalink snippets
and fill them in.