### PR TITLE
[DM-32258] Add vo-cutouts chart

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.2.7
+version: 4.2.8
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -148,6 +148,7 @@ config:
     "exec:admin": "Administrative access to all APIs"
     "exec:notebook": "Use the Notebook Aspect"
     "exec:portal": "Use the Portal Aspect"
+    "read:image": "Retrieve images from project datasets"
     "read:tap": "Execute SELECT queries in the TAP interface on project datasets"
     "user:token": "Can create and modify user tokens"
 

--- a/charts/vo-cutouts/Chart.yaml
+++ b/charts/vo-cutouts/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: vo-cutouts
+version: 0.1.0
+description: Image cutout service complying with IVOA SODA
+home: https://github.com/lsst-sqre/vo-cutouts
+maintainers:
+  - name: rra
+appVersion: 0.1.0

--- a/charts/vo-cutouts/README.md
+++ b/charts/vo-cutouts/README.md
@@ -50,9 +50,10 @@ Image cutout service complying with IVOA SODA
 | image.repository | string | `"lsstsqre/vo-cutouts"` | vo-cutouts image to use |
 | image.tag | string | The appVersion of the chart | Tag of vo-cutouts image to use |
 | imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
-| ingress.annotations | object | `{"nginx.ingress.kubernetes.io/auth-method":"GET","nginx.ingress.kubernetes.io/auth-url":"http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=read:image"}` | Additional annotations to add to the ingress |
+| ingress.annotations | object | `{}` | Additional annotations to add to the ingress |
 | ingress.enabled | bool | `true` | Whether to create an ingress |
-| ingress.host | string | `""` | Hostname for the ingress. This should normally be the same as config.host. |
+| ingress.gafaelfawrAuthQuery | string | `"scope=read:image"` | Gafaelfawr auth query string |
+| ingress.host | string | `""` | Hostname for the ingress |
 | ingress.tls | list | `[]` | Configures TLS for the ingress if needed. If multiple ingresses share the same hostname, only one of them needs a TLS configuration. |
 | nameOverride | string | `""` | Override the base name for resources |
 | networkPolicy.enabled | bool | `false` | Whether to restrict access to the image cutout service. Only enable if the ingress controller namespace is tagged with `gafaelfawr.lsst.io/ingress: "true"`. |

--- a/charts/vo-cutouts/README.md
+++ b/charts/vo-cutouts/README.md
@@ -1,0 +1,81 @@
+# vo-cutouts
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+Image cutout service complying with IVOA SODA
+
+**Homepage:** <https://github.com/lsst-sqre/vo-cutouts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| rra |  |  |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for the vo-cutouts frontend pod |
+| cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases on Google Cloud |
+| cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
+| cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
+| cloudsql.image.tag | string | `"1.26.0-buster"` | Cloud SQL Auth Proxy tag to use |
+| cloudsql.instanceConnectionName | string | `""` | Instance connection name for a CloudSQL PostgreSQL instance |
+| cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role |
+| config.butlerRepository | string | None, must be set | Configuration for the Butler repository to use |
+| config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
+| config.lifetime | int | 604800 (1 week) | Lifetime of job results in seconds |
+| config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
+| config.syncTimeout | int | 60 (1 minute) | Timeout for results from a sync cutout in seconds |
+| config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
+| cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
+| cutoutWorker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for cutout workers |
+| cutoutWorker.image.repository | string | `"lsstsqre/centos"` | Stack image to use for cutouts |
+| cutoutWorker.image.tag | string | `"7-stack-lsst_distrib-w_2021_43"` | Stack image tag to use |
+| cutoutWorker.nodeSelector | object | `{}` | Node selection rules for the cutout worker pod |
+| cutoutWorker.podAnnotations | object | `{}` | Annotations for the cutout worker pod |
+| cutoutWorker.replicaCount | int | `1` | Number of cutout worker pods to start |
+| cutoutWorker.resources | object | `{}` | Resource limits and requests for the cutout worker pod |
+| cutoutWorker.tolerations | list | `[]` | Tolerations for the cutout worker pod |
+| databaseWorker.affinity | object | `{}` | Affinity rules for the database worker pod |
+| databaseWorker.nodeSelector | object | `{}` | Node selection rules for the database worker pod |
+| databaseWorker.podAnnotations | object | `{}` | Annotations for the database worker pod |
+| databaseWorker.replicaCount | int | `1` | Number of database worker pods to start |
+| databaseWorker.resources | object | `{}` | Resource limits and requests for the database worker pod |
+| databaseWorker.tolerations | list | `[]` | Tolerations for the database worker pod |
+| fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the vo-cutouts image |
+| image.repository | string | `"lsstsqre/vo-cutouts"` | vo-cutouts image to use |
+| image.tag | string | The appVersion of the chart | Tag of vo-cutouts image to use |
+| imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
+| ingress.annotations | object | `{"nginx.ingress.kubernetes.io/auth-method":"GET","nginx.ingress.kubernetes.io/auth-url":"http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=read:image"}` | Additional annotations to add to the ingress |
+| ingress.enabled | bool | `true` | Whether to create an ingress |
+| ingress.host | string | `""` | Hostname for the ingress. This should normally be the same as config.host. |
+| ingress.tls | list | `[]` | Configures TLS for the ingress if needed. If multiple ingresses share the same hostname, only one of them needs a TLS configuration. |
+| nameOverride | string | `""` | Override the base name for resources |
+| networkPolicy.enabled | bool | `false` | Whether to restrict access to the image cutout service. Only enable if the ingress controller namespace is tagged with `gafaelfawr.lsst.io/ingress: "true"`. |
+| nodeSelector | object | `{}` | Node selector rules for the vo-cutouts frontend pod |
+| podAnnotations | object | `{}` | Annotations for the vo-cutouts frontend pod |
+| redis.affinity | object | `{}` | Affinity rules for the Redis pod |
+| redis.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the Redis image |
+| redis.image.repository | string | `"redis"` | Redis image to use |
+| redis.image.tag | string | `"6.2.6"` | Redis image tag to use |
+| redis.nodeSelector | object | `{}` | Node selection rules for the Redis pod |
+| redis.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |
+| redis.persistence.enabled | bool | `true` | Whether to persist Redis storage and thus tokens. Setting this to false will use `emptyDir` and reset all tokens on every restart. Only use this for a test deployment. |
+| redis.persistence.size | string | `"100Mi"` | Amount of persistent storage to request |
+| redis.persistence.storageClass | string | `""` | Class of storage to request |
+| redis.persistence.volumeClaimName | string | `""` | Use an existing PVC, not dynamic provisioning. If this is set, the size, storageClass, and accessMode settings are ignored. |
+| redis.podAnnotations | object | `{}` | Pod annotations for the Redis pod |
+| redis.tolerations | list | `[]` | Tolerations for the Redis pod |
+| replicaCount | int | `1` | Number of web frontend pods to start |
+| resources | object | `{}` | Resource limits and requests for the vo-cutouts frontend pod |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account. If CloudSQL is in use, the annotation specifying the Google service account will also be added. |
+| serviceAccount.create | bool | `false` | Force creation of a service account. Normally, no service account is used or mounted. If CloudSQL is enabled, a service account is always created regardless of this value. |
+| serviceAccount.name | string | Name based on the fullname template | Name of the service account to use |
+| tolerations | list | `[]` | Tolerations for the vo-cutouts frontend pod |
+| vaultSecretsPath | string | None, must be set | Path to the Vault secret (`secret/k8s_operator/<host>/vo-cutouts`, for example) |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/vo-cutouts/README.md
+++ b/charts/vo-cutouts/README.md
@@ -23,6 +23,7 @@ Image cutout service complying with IVOA SODA
 | cloudsql.image.tag | string | `"1.26.0-buster"` | Cloud SQL Auth Proxy tag to use |
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a CloudSQL PostgreSQL instance |
 | cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role |
+| config.butlerCollection | string | None, must be set | Collection of source data from which cutouts will be taken |
 | config.butlerRepository | string | None, must be set | Configuration for the Butler repository to use |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.lifetime | int | 604800 (1 week) | Lifetime of job results in seconds |

--- a/charts/vo-cutouts/templates/_helpers.tpl
+++ b/charts/vo-cutouts/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vo-cutouts.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vo-cutouts.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vo-cutouts.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "vo-cutouts.labels" -}}
+helm.sh/chart: {{ include "vo-cutouts.chart" . }}
+{{ include "vo-cutouts.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "vo-cutouts.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vo-cutouts.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "vo-cutouts.serviceAccountName" -}}
+{{- if or .Values.serviceAccount.create .Values.cloudsql.enabled }}
+{{- default (include "vo-cutouts.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/vo-cutouts/templates/configmap.yaml
+++ b/charts/vo-cutouts/templates/configmap.yaml
@@ -10,6 +10,6 @@ data:
   CUTOUT_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
   CUTOUT_TIMEOUT: {{ .Values.config.timeout | quote }}
   CUTOUT_LIFETIME: {{ .Values.config.lifetime | quote }}
-  CUTOUT_REDIS_HOST: "redis://{{ template "vo-cutouts.fullname" . }}-redis.{{ .Release.namespace }}"
+  CUTOUT_REDIS_HOST: "redis://{{ template "vo-cutouts.fullname" . }}-redis.{{ .Release.Namespace }}"
   CUTOUT_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}
-  SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  SAFIR_LOG_LEVEL: {{ .Values.config.loglevel | quote }}

--- a/charts/vo-cutouts/templates/configmap.yaml
+++ b/charts/vo-cutouts/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "vo-cutouts.labels" . | nindent 4 }}
 data:
   CUTOUT_BUTLER_REPOSITORY: {{ required "config.butlerRepository must be set" .Values.config.butlerRepository | quote }}
+  CUTOUT_BUTLER_COLLECTION: {{ required "config.butlerCollection must be set" .Values.config.butlerCollection | quote }}
   CUTOUT_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
   CUTOUT_TIMEOUT: {{ .Values.config.timeout | quote }}
   CUTOUT_LIFETIME: {{ .Values.config.lifetime | quote }}

--- a/charts/vo-cutouts/templates/configmap.yaml
+++ b/charts/vo-cutouts/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-config
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+data:
+  CUTOUT_BUTLER_REPOSITORY: {{ required "config.butlerRepository must be set" .Values.config.butlerRepository | quote }}
+  CUTOUT_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
+  CUTOUT_TIMEOUT: {{ .Values.config.timeout | quote }}
+  CUTOUT_LIFETIME: {{ .Values.config.lifetime | quote }}
+  CUTOUT_REDIS_HOST: "redis://{{ template "vo-cutouts.fullname" . }}-redis.{{ .Release.namespace }}"
+  CUTOUT_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}
+  SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}

--- a/charts/vo-cutouts/templates/configmap.yaml
+++ b/charts/vo-cutouts/templates/configmap.yaml
@@ -10,6 +10,6 @@ data:
   CUTOUT_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
   CUTOUT_TIMEOUT: {{ .Values.config.timeout | quote }}
   CUTOUT_LIFETIME: {{ .Values.config.lifetime | quote }}
-  CUTOUT_REDIS_HOST: "redis://{{ template "vo-cutouts.fullname" . }}-redis.{{ .Release.Namespace }}"
+  CUTOUT_REDIS_HOST: "{{ template "vo-cutouts.fullname" . }}-redis.{{ .Release.Namespace }}"
   CUTOUT_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}
   SAFIR_LOG_LEVEL: {{ .Values.config.loglevel | quote }}

--- a/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
@@ -30,6 +30,28 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      initContainers:
+        - name: "fix-secret-permissions"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              # The Butler PostgreSQL secret must be owned by the appuser
+              cp -RL /etc/vo-cutouts/secrets-raw/* /etc/vo-cutouts/secrets
+              chown appuser:appuser /etc/vo-cutouts/secrets/*
+              chmod 0400 /etc/vo-cutouts/secrets/*
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts:
+            - name: "secrets"
+              mountPath: "/etc/vo-cutouts/secrets"
+            - name: "secrets-raw"
+              mountPath: "/etc/vo-cutouts/secrets-raw"
+              readOnly: true
       containers:
         - name: "cutout-worker"
           securityContext:
@@ -75,13 +97,15 @@ spec:
           volumeMounts:
             - name: "secrets"
               mountPath: "/etc/vo-cutouts/secrets"
-              readOnly: true
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
         - name: "secrets"
+          emptyDir: {}
+        - name: "secrets-raw"
           secret:
             secretName: {{ template "vo-cutouts.fullname" . }}-secret
+            defaultMode: 0400
         - name: "tmp"
           emptyDir: {}
       {{- with .Values.cutoutWorker.nodeSelector }}

--- a/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
@@ -85,6 +85,8 @@ spec:
                   key: "redis-password"
             - name: "PGPASSFILE"
               value: "/etc/vo-cutouts/secrets/postgres-credentials"
+            - name: "S3_ENDPOINT_URL"
+              value: "https://storage.googleapis.com"
           envFrom:
             - configMapRef:
                 name: {{ template "vo-cutouts.fullname" . }}-config

--- a/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-worker
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.databaseWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "cutout-worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.databaseWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "vo-cutouts.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "cutout-worker"
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: "cutout-worker"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.cutoutWorker.image.repository }}:{{ .Values.cutoutWorker.image.tag }}"
+          imagePullPolicy: {{ .Values.cutoutWorker.image.pullPolicy | quote }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              source /opt/lsst/software/stack/loadLSST.bash
+              setup lsst_distrib
+              python3 -m venv /tmp/worker-venv
+              cd /tmp/worker-venv
+              pip install 'dramatiq[redis]'
+              git clone --depth 1 -b '{{ .Values.image.tag | default .Chart.AppVersion }}' https://github.com/lsst-sqre/vo-cutouts
+              dramatiq vo-cutouts/src/vocutouts/workers.py -Q cutout
+          env:
+            - name: "CUTOUT_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "database-password"
+            - name: "CUTOUT_REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "redis-password"
+          envFrom:
+            - configMapRef:
+                name: {{ template "vo-cutouts.fullname" . }}-config
+          {{- with .Values.cutoutWorker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: "tmp"
+              mountPath: "/tmp"
+      volumes:
+        - name: "tmp"
+          emptyDir: {}
+      {{- with .Values.cutoutWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cutoutWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cutoutWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
@@ -46,9 +46,12 @@ spec:
             - |
               source /opt/lsst/software/stack/loadLSST.bash
               setup lsst_distrib
+              set -x
               python3 -m venv /tmp/worker-venv
-              cd /tmp/worker-venv
-              pip install 'dramatiq[redis]'
+              export PATH="/tmp/worker-venv/bin:$PATH"
+              cd /tmp
+              pip install --quiet --no-cache-dir 'dramatiq[redis]'
+              rm -r vo-cutouts
               git clone --depth 1 -b '{{ .Values.image.tag | default .Chart.AppVersion }}' https://github.com/lsst-sqre/vo-cutouts
               dramatiq vo-cutouts/src/vocutouts/workers.py -Q cutout
           env:

--- a/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
@@ -52,6 +52,8 @@ spec:
               git clone --depth 1 -b '{{ .Values.image.tag | default .Chart.AppVersion }}' https://github.com/lsst-sqre/vo-cutouts
               dramatiq vo-cutouts/src/vocutouts/workers.py -Q cutout
           env:
+            - name: "AWS_SHARED_CREDENTIALS_FILE"
+              value: "/etc/vo-cutouts/secrets/aws-credentials"
             - name: "CUTOUT_DATABASE_PASSWORD"
               valueFrom:
                 secretKeyRef:
@@ -62,6 +64,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "vo-cutouts.fullname" . }}-secret
                   key: "redis-password"
+            - name: "PGPASSFILE"
+              value: "/etc/vo-cutouts/secrets/postgres-credentials"
           envFrom:
             - configMapRef:
                 name: {{ template "vo-cutouts.fullname" . }}-config
@@ -70,9 +74,15 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: "secrets"
+              mountPath: "/etc/vo-cutouts/secrets"
+              readOnly: true
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
+        - name: "secrets"
+          secret:
+            secretName: {{ template "vo-cutouts.fullname" . }}-secret
         - name: "tmp"
           emptyDir: {}
       {{- with .Values.cutoutWorker.nodeSelector }}

--- a/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
@@ -52,16 +52,12 @@ spec:
               cd /tmp
               pip install --quiet --no-cache-dir 'dramatiq[redis]'
               rm -r vo-cutouts
-              git clone --depth 1 -b '{{ .Values.image.tag | default .Chart.AppVersion }}' https://github.com/lsst-sqre/vo-cutouts
-              dramatiq vo-cutouts/src/vocutouts/workers.py -Q cutout
+              git clone --depth 1 -b "$(echo '{{ .Values.image.tag | default .Chart.AppVersion }}' | sed 's,tickets-,tickets/,')" https://github.com/lsst-sqre/vo-cutouts
+              cd vo-cutouts/src/vocutouts
+              dramatiq workers.py -Q cutout
           env:
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/etc/vo-cutouts/secrets/aws-credentials"
-            - name: "CUTOUT_DATABASE_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "vo-cutouts.fullname" . }}-secret
-                  key: "database-password"
             - name: "CUTOUT_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-cutout-worker.yaml
@@ -69,14 +69,12 @@ spec:
               source /opt/lsst/software/stack/loadLSST.bash
               setup lsst_distrib
               set -x
-              python3 -m venv /tmp/worker-venv
-              export PATH="/tmp/worker-venv/bin:$PATH"
-              cd /tmp
               pip install --quiet --no-cache-dir 'dramatiq[redis]'
+              cd /tmp
               rm -r vo-cutouts
               git clone --depth 1 -b "$(echo '{{ .Values.image.tag | default .Chart.AppVersion }}' | sed 's,tickets-,tickets/,')" https://github.com/lsst-sqre/vo-cutouts
               cd vo-cutouts/src/vocutouts
-              dramatiq workers.py -Q cutout
+              python /home/lsst/.local/bin/dramatiq workers -Q cutout
           env:
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/etc/vo-cutouts/secrets/aws-credentials"
@@ -95,11 +93,15 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: "local"
+              mountPath: "/home/lsst"
             - name: "secrets"
               mountPath: "/etc/vo-cutouts/secrets"
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
+        - name: "local"
+          emptyDir: {}
         - name: "secrets"
           emptyDir: {}
         - name: "secrets-raw"

--- a/charts/vo-cutouts/templates/deployment-db-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-db-worker.yaml
@@ -85,6 +85,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: "tmp"
+              mountPath: "/tmp"
+      volumes:
+        - name: "tmp"
+          emptyDir: {}
       {{- with .Values.databaseWorker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/vo-cutouts/templates/deployment-db-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-db-worker.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-db-worker
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.databaseWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "db-worker"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.databaseWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "vo-cutouts.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "db-worker"
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.cloudsql.enabled }}
+      serviceAccountName: {{ include "vo-cutouts.serviceAccountName" . }}
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+        {{- end }}
+        - name: "db-worker"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command:
+            - "dramatiq"
+            - "vocutouts.actors"
+            - "-Q"
+            - "uws"
+          env:
+            - name: "CUTOUT_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "database-password"
+            - name: "CUTOUT_REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "redis-password"
+          envFrom:
+            - configMapRef:
+                name: {{ template "vo-cutouts.fullname" . }}-config
+          {{- with .Values.databaseWorker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.databaseWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.databaseWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.databaseWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/vo-cutouts/templates/deployment-db-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-db-worker.yaml
@@ -89,6 +89,8 @@ spec:
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
+        # Dramatiq enables its Prometheus middleware by default, which
+        # requires writable /tmp.
         - name: "tmp"
           emptyDir: {}
       {{- with .Values.databaseWorker.nodeSelector }}

--- a/charts/vo-cutouts/templates/deployment-worker.yaml
+++ b/charts/vo-cutouts/templates/deployment-worker.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: "cutout-worker"
+      app.kubernetes.io/component: "worker"
   template:
     metadata:
       annotations:
@@ -19,7 +19,7 @@ spec:
         {{- end }}
       labels:
         {{- include "vo-cutouts.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: "cutout-worker"
+        app.kubernetes.io/component: "worker"
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -30,6 +30,13 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+
+      # Butler uses a pgpass file to authenticate to its database, and
+      # PostgreSQL unfortunately requires its pgpass file be owned by the
+      # current user and mode 0600, but Kubernetes has no way of controlling
+      # the ownership of a mounted secret.  We therefore use a privileged init
+      # container to copy the secrets into a shared emptyDir and change their
+      # ownership and permissions.
       initContainers:
         - name: "fix-secret-permissions"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -38,7 +45,6 @@ spec:
             - "/bin/bash"
             - "-c"
             - |
-              # The Butler PostgreSQL secret must be owned by the appuser
               cp -RL /etc/vo-cutouts/secrets-raw/* /etc/vo-cutouts/secrets
               chown appuser:appuser /etc/vo-cutouts/secrets/*
               chmod 0400 /etc/vo-cutouts/secrets/*
@@ -53,7 +59,7 @@ spec:
               mountPath: "/etc/vo-cutouts/secrets-raw"
               readOnly: true
       containers:
-        - name: "cutout-worker"
+        - name: "worker"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -62,6 +68,23 @@ spec:
             readOnlyRootFilesystem: true
           image: "{{ .Values.cutoutWorker.image.repository }}:{{ .Values.cutoutWorker.image.tag }}"
           imagePullPolicy: {{ .Values.cutoutWorker.image.pullPolicy | quote }}
+
+          # This tricky command bootstraps the worker on every container
+          # restart.  It requires there exist a branch in the vo-cutouts
+          # GitHub repository that matches the tag (changing "tickets-" to
+          # "tickets/") of the Docker image to use, and retrieves the worker
+          # Python file from there.  It then installs Dramatiq and runs it
+          # with the stack Python.
+          #
+          # The path in the user home directory uesd by pip install run as a
+          # non-root user is in the Python path by default, so packages
+          # installed that way will be picked up by the stack Python.
+          # However, ~/.local/bin is not in PATH and we want to force the
+          # stack Python (which should be first in PATH), so invoke Dramatiq
+          # with an explicit execution of python.
+          #
+          # This approach is probably temporary and will be replaced with a
+          # more reproducible way of getting the worker source.
           command:
             - "/bin/bash"
             - "-c"
@@ -75,18 +98,23 @@ spec:
               git clone --depth 1 -b "$(echo '{{ .Values.image.tag | default .Chart.AppVersion }}' | sed 's,tickets-,tickets/,')" https://github.com/lsst-sqre/vo-cutouts
               cd vo-cutouts/src/vocutouts
               python /home/lsst/.local/bin/dramatiq workers -Q cutout
+
           env:
+            # The following are used by Butler to retrieve its configuration
+            # and authenticate to its database.
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/etc/vo-cutouts/secrets/aws-credentials"
+            - name: "PGPASSFILE"
+              value: "/etc/vo-cutouts/secrets/postgres-credentials"
+            - name: "S3_ENDPOINT_URL"
+              value: "https://storage.googleapis.com"
+
+            # Authentication to the Redis queue for Dramatiq.
             - name: "CUTOUT_REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:
                   name: {{ template "vo-cutouts.fullname" . }}-secret
                   key: "redis-password"
-            - name: "PGPASSFILE"
-              value: "/etc/vo-cutouts/secrets/postgres-credentials"
-            - name: "S3_ENDPOINT_URL"
-              value: "https://storage.googleapis.com"
           envFrom:
             - configMapRef:
                 name: {{ template "vo-cutouts.fullname" . }}-config
@@ -102,6 +130,7 @@ spec:
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
+        # The /home/lsst home directory, which is used by pip install.
         - name: "local"
           emptyDir: {}
         - name: "secrets"

--- a/charts/vo-cutouts/templates/deployment.yaml
+++ b/charts/vo-cutouts/templates/deployment.yaml
@@ -96,10 +96,14 @@ spec:
             - name: "secrets"
               mountPath: "/etc/vo-cutouts/secrets"
               readOnly: true
+            - name: "tmp"
+              mountPath: "/tmp"
       volumes:
         - name: "secrets"
           secret:
             secretName: {{ template "vo-cutouts.fullname" . }}-secret
+        - name: "tmp"
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/vo-cutouts/templates/deployment.yaml
+++ b/charts/vo-cutouts/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "frontend"
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "vo-cutouts.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "frontend"
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.cloudsql.enabled }}
+      serviceAccountName: {{ include "vo-cutouts.serviceAccountName" . }}
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        {{- if .Values.cloudsql.enabled }}
+        - name: "cloud-sql-proxy"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+          imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy | quote }}
+          command:
+            - "/cloud_sql_proxy"
+            - "-ip_address_types=PRIVATE"
+            - "-instances={{ required "cloudsql.instanceConnectionName must be specified" .Values.cloudsql.instanceConnectionName }}=tcp:5432"
+        {{- end }}
+        - name: "vo-cutouts"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          ports:
+            - containerPort: 8080
+              name: "http"
+              protocol: "TCP"
+          env:
+            - name: "CUTOUT_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "database-password"
+            - name: "CUTOUT_REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "redis-password"
+          envFrom:
+            - configMapRef:
+                name: {{ template "vo-cutouts.fullname" . }}-config
+          readinessProbe:
+            httpGet:
+              path: "/cutout/availability"
+              port: "http"
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/vo-cutouts/templates/deployment.yaml
+++ b/charts/vo-cutouts/templates/deployment.yaml
@@ -67,6 +67,8 @@ spec:
               name: "http"
               protocol: "TCP"
           env:
+            - name: "AWS_SHARED_CREDENTIALS_FILE"
+              value: "/etc/vo-cutouts/secrets/aws-credentials"
             - name: "CUTOUT_DATABASE_PASSWORD"
               valueFrom:
                 secretKeyRef:
@@ -77,6 +79,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "vo-cutouts.fullname" . }}-secret
                   key: "redis-password"
+            - name: "PGPASSFILE"
+              value: "/etc/vo-cutouts/secrets/postgres-credentials"
           envFrom:
             - configMapRef:
                 name: {{ template "vo-cutouts.fullname" . }}-config
@@ -88,6 +92,14 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: "secrets"
+              mountPath: "/etc/vo-cutouts/secrets"
+              readOnly: true
+      volumes:
+        - name: "secrets"
+          secret:
+            secretName: {{ template "vo-cutouts.fullname" . }}-secret
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/vo-cutouts/templates/deployment.yaml
+++ b/charts/vo-cutouts/templates/deployment.yaml
@@ -79,6 +79,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "vo-cutouts.fullname" . }}-secret
                   key: "redis-password"
+            - name: "GOOGLE_APPLICATION_CREDENTIALS"
+              value: "/etc/vo-cutouts/secrets/google-credentials"
             - name: "PGPASSFILE"
               value: "/etc/vo-cutouts/secrets/postgres-credentials"
           envFrom:

--- a/charts/vo-cutouts/templates/deployment.yaml
+++ b/charts/vo-cutouts/templates/deployment.yaml
@@ -34,6 +34,28 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      initContainers:
+        - name: "fix-secret-permissions"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              # The Butler PostgreSQL secret must be owned by the appuser
+              cp -RL /etc/vo-cutouts/secrets-raw/* /etc/vo-cutouts/secrets
+              chown appuser:appuser /etc/vo-cutouts/secrets/*
+              chmod 0400 /etc/vo-cutouts/secrets/*
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts:
+            - name: "secrets"
+              mountPath: "/etc/vo-cutouts/secrets"
+            - name: "secrets-raw"
+              mountPath: "/etc/vo-cutouts/secrets-raw"
+              readOnly: true
       containers:
         {{- if .Values.cloudsql.enabled }}
         - name: "cloud-sql-proxy"
@@ -97,13 +119,15 @@ spec:
           volumeMounts:
             - name: "secrets"
               mountPath: "/etc/vo-cutouts/secrets"
-              readOnly: true
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
         - name: "secrets"
+          emptyDir: {}
+        - name: "secrets-raw"
           secret:
             secretName: {{ template "vo-cutouts.fullname" . }}-secret
+            defaultMode: 0400
         - name: "tmp"
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/charts/vo-cutouts/templates/deployment.yaml
+++ b/charts/vo-cutouts/templates/deployment.yaml
@@ -34,6 +34,13 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+
+      # Butler uses a pgpass file to authenticate to its database, and
+      # PostgreSQL unfortunately requires its pgpass file be owned by the
+      # current user and mode 0600, but Kubernetes has no way of controlling
+      # the ownership of a mounted secret.  We therefore use a privileged init
+      # container to copy the secrets into a shared emptyDir and change their
+      # ownership and permissions.
       initContainers:
         - name: "fix-secret-permissions"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -42,7 +49,6 @@ spec:
             - "/bin/bash"
             - "-c"
             - |
-              # The Butler PostgreSQL secret must be owned by the appuser
               cp -RL /etc/vo-cutouts/secrets-raw/* /etc/vo-cutouts/secrets
               chown appuser:appuser /etc/vo-cutouts/secrets/*
               chmod 0400 /etc/vo-cutouts/secrets/*
@@ -56,6 +62,7 @@ spec:
             - name: "secrets-raw"
               mountPath: "/etc/vo-cutouts/secrets-raw"
               readOnly: true
+
       containers:
         {{- if .Values.cloudsql.enabled }}
         - name: "cloud-sql-proxy"
@@ -89,8 +96,20 @@ spec:
               name: "http"
               protocol: "TCP"
           env:
+            # The following are used by Butler to retrieve its configuration
+            # and authenticate to its database.
             - name: "AWS_SHARED_CREDENTIALS_FILE"
               value: "/etc/vo-cutouts/secrets/aws-credentials"
+            - name: "PGPASSFILE"
+              value: "/etc/vo-cutouts/secrets/postgres-credentials"
+            - name: "S3_ENDPOINT_URL"
+              value: "https://storage.googleapis.com"
+
+            # Used to generate signed URLs into Butler collections.
+            - name: "GOOGLE_APPLICATION_CREDENTIALS"
+              value: "/etc/vo-cutouts/secrets/google-credentials"
+
+            # Authentication to the UWS queuing system and job database.
             - name: "CUTOUT_DATABASE_PASSWORD"
               valueFrom:
                 secretKeyRef:
@@ -101,12 +120,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "vo-cutouts.fullname" . }}-secret
                   key: "redis-password"
-            - name: "GOOGLE_APPLICATION_CREDENTIALS"
-              value: "/etc/vo-cutouts/secrets/google-credentials"
-            - name: "PGPASSFILE"
-              value: "/etc/vo-cutouts/secrets/postgres-credentials"
-            - name: "S3_ENDPOINT_URL"
-              value: "https://storage.googleapis.com"
           envFrom:
             - configMapRef:
                 name: {{ template "vo-cutouts.fullname" . }}-config
@@ -130,6 +143,8 @@ spec:
           secret:
             secretName: {{ template "vo-cutouts.fullname" . }}-secret
             defaultMode: 0400
+        # Dramatiq enables its Prometheus middleware by default, which
+        # requires writable /tmp.
         - name: "tmp"
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/charts/vo-cutouts/templates/deployment.yaml
+++ b/charts/vo-cutouts/templates/deployment.yaml
@@ -105,6 +105,8 @@ spec:
               value: "/etc/vo-cutouts/secrets/google-credentials"
             - name: "PGPASSFILE"
               value: "/etc/vo-cutouts/secrets/postgres-credentials"
+            - name: "S3_ENDPOINT_URL"
+              value: "https://storage.googleapis.com"
           envFrom:
             - configMapRef:
                 name: {{ template "vo-cutouts.fullname" . }}-config

--- a/charts/vo-cutouts/templates/ingress.yaml
+++ b/charts/vo-cutouts/templates/ingress.yaml
@@ -7,6 +7,9 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?{{ required "ingress.gafaelfawrAuthQuery must be set" .Values.ingress.gafaelfawrAuthQuery }}"
     nginx.ingress.kubernetes.io/rewrite-target: "/cutout$1"
     nginx.ingress.kubernetes.io/use-regex: "true"
     {{- with .Values.ingress.annotations }}

--- a/charts/vo-cutouts/templates/ingress.yaml
+++ b/charts/vo-cutouts/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- /*
+  Update apiVersion when Argo CD has been fixed to pass in cluster
+  capabilities, or when all clusters are running Kubernetes 1.19 or later.
+*/ -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: "/api/cutouts$1"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "vo-cutouts.fullname" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  rules:
+    - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: "/api/cutouts(.*)"
+            backend:
+              serviceName: {{ template "vo-cutouts.fullname" . }}
+              servicePort: 8080
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}

--- a/charts/vo-cutouts/templates/ingress.yaml
+++ b/charts/vo-cutouts/templates/ingress.yaml
@@ -7,7 +7,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: "/api/cutouts$1"
+    nginx.ingress.kubernetes.io/rewrite-target: "/cutout$1"
     nginx.ingress.kubernetes.io/use-regex: "true"
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -20,7 +20,7 @@ spec:
     - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
       http:
         paths:
-          - path: "/api/cutouts(.*)"
+          - path: "/api/cutout(.*)"
             backend:
               serviceName: {{ template "vo-cutouts.fullname" . }}
               servicePort: 8080

--- a/charts/vo-cutouts/templates/networkpolicy.yaml
+++ b/charts/vo-cutouts/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound access to the frontend component.
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "frontend"
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow inbound access to Redis from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              gafaelfawr.lsst.io/ingress: "true"
+      ports:
+        - protocol: "TCP"
+          port: 8080
+{{- end }}

--- a/charts/vo-cutouts/templates/redis-networkpolicy.yaml
+++ b/charts/vo-cutouts/templates/redis-networkpolicy.yaml
@@ -24,7 +24,7 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "vo-cutouts.selectorLabels" . | nindent 14 }}
-              app.kubernetes.io/component: "cutout-worker"
+              app.kubernetes.io/component: "worker"
         - podSelector:
             matchLabels:
               {{- include "vo-cutouts.selectorLabels" . | nindent 14 }}

--- a/charts/vo-cutouts/templates/redis-networkpolicy.yaml
+++ b/charts/vo-cutouts/templates/redis-networkpolicy.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-redis
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    # This policy controls inbound and outbound access to the Redis component.
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "redis"
+  policyTypes:
+    - Ingress
+    # Deny all outbound access; Redis doesn't need to talk to anything.
+    - Egress
+  ingress:
+    # Allow inbound access to Redis from all other components.
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "vo-cutouts.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "frontend"
+        - podSelector:
+            matchLabels:
+              {{- include "vo-cutouts.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "cutout-worker"
+        - podSelector:
+            matchLabels:
+              {{- include "vo-cutouts.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: "db-worker"
+      ports:
+        - protocol: "TCP"
+          port: 6379

--- a/charts/vo-cutouts/templates/redis-service.yml
+++ b/charts/vo-cutouts/templates/redis-service.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-redis
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      protocol: "TCP"
+      targetPort: 6379
+  selector:
+    {{- include "vo-cutouts.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "redis"
+  sessionAffinity: None

--- a/charts/vo-cutouts/templates/redis-statefulset.yaml
+++ b/charts/vo-cutouts/templates/redis-statefulset.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-redis
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "vo-cutouts.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "redis"
+  serviceName: "redis"
+  template:
+    metadata:
+      {{- with .Values.redis.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "vo-cutouts.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "redis"
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        fsGroup: 999
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+      automountServiceAccountToken: false
+      containers:
+        - name: "redis"
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy | quote }}
+          args:
+            - "redis-server"
+            - "--appendonly"
+            - "yes"
+            - "--requirepass"
+            - "$(REDIS_PASSWORD)"
+          env:
+            - name: "REDIS_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "vo-cutouts.fullname" . }}-secret
+                  key: "redis-password"
+          livenessProbe:
+            exec:
+              command:
+                - "sh"
+                - "-c"
+                - "redis-cli -h $(hostname) incr health:counter"
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              cpu: "1"
+            requests:
+              cpu: "100m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: {{ template "vo-cutouts.fullname" . }}-redis-data
+              mountPath: "/data"
+      {{- if (not .Values.redis.persistence.enabled) }}
+      volumes:
+        - name: {{ template "vo-cutouts.fullname" . }}-redis-data
+          emptyDir: {}
+      {{- else if .Values.redis.persistence.volumeClaimName }}
+      volumes:
+        - name: {{ template "vo-cutouts.fullname" . }}-redis-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.redis.persistence.volumeClaimName | quote }}
+      {{- end }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if (and .Values.redis.persistence.enabled (not .Values.redis.persistence.volumeClaimName)) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ template "vo-cutouts.fullname" . }}-redis-data
+      spec:
+        accessModes:
+          - {{ .Values.redis.persistence.accessMode | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size | quote }}
+        {{- if .Values.redis.persistence.storageClass }}
+        storageClassName: {{ .Values.redis.persistence.storageClass | quote }}
+        {{- end }}
+  {{- end }}

--- a/charts/vo-cutouts/templates/service.yaml
+++ b/charts/vo-cutouts/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: "TCP"
+      port: 8080
+      targetPort: "http"
+  selector:
+    {{- include "vo-cutouts.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "frontend"
+  sessionAffinity: None

--- a/charts/vo-cutouts/templates/serviceaccount.yaml
+++ b/charts/vo-cutouts/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if or .Values.serviceAccount.create .Values.cloudsql.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vo-cutouts.serviceAccountName" . }}
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.cloudsql.enabled }}
+    iam.gke.io/gcp-service-account: {{ required "cloudsql.serviceAccount must be set to a valid Google service account" .Values.cloudsql.serviceAccount | quote }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/vo-cutouts/templates/vault-secret.yaml
+++ b/charts/vo-cutouts/templates/vault-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: {{ template "vo-cutouts.fullname" . }}-secret
+  labels:
+    {{- include "vo-cutouts.labels" . | nindent 4 }}
+spec:
+  path: {{ required "vaultSecretsPath must be set" .Values.vaultSecretsPath | quote }}
+  type: Opaque

--- a/charts/vo-cutouts/values.yaml
+++ b/charts/vo-cutouts/values.yaml
@@ -44,6 +44,7 @@ ingress:
   # -- Additional annotations to add to the ingress
   annotations:
     nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=read:image"
 
   # -- Hostname for the ingress. This should normally be the same as

--- a/charts/vo-cutouts/values.yaml
+++ b/charts/vo-cutouts/values.yaml
@@ -42,14 +42,13 @@ ingress:
   enabled: true
 
   # -- Additional annotations to add to the ingress
-  annotations:
-    nginx.ingress.kubernetes.io/auth-method: "GET"
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User
-    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=read:image"
+  annotations: {}
 
-  # -- Hostname for the ingress. This should normally be the same as
-  # config.host.
+  # -- Hostname for the ingress
   host: ""
+
+  # -- Gafaelfawr auth query string
+  gafaelfawrAuthQuery: "scope=read:image"
 
   # -- Configures TLS for the ingress if needed. If multiple ingresses share
   # the same hostname, only one of them needs a TLS configuration.

--- a/charts/vo-cutouts/values.yaml
+++ b/charts/vo-cutouts/values.yaml
@@ -85,6 +85,10 @@ config:
   # @default -- None, must be set
   butlerRepository: ""
 
+  # -- Collection of source data from which cutouts will be taken
+  # @default -- None, must be set
+  butlerCollection: ""
+
   # -- URL for the PostgreSQL database
   # @default -- None, must be set
   databaseUrl: ""

--- a/charts/vo-cutouts/values.yaml
+++ b/charts/vo-cutouts/values.yaml
@@ -1,0 +1,217 @@
+# Default values for vo-cutouts.
+
+# -- Number of web frontend pods to start
+replicaCount: 1
+
+# -- Override the base name for resources
+nameOverride: ""
+
+# -- Override the full name for resources (includes the release name)
+fullnameOverride: ""
+
+image:
+  # -- vo-cutouts image to use
+  repository: "lsstsqre/vo-cutouts"
+
+  # -- Pull policy for the vo-cutouts image
+  pullPolicy: "IfNotPresent"
+
+  # -- Tag of vo-cutouts image to use
+  # @default -- The appVersion of the chart
+  tag: ""
+
+# -- Secret names to use for all Docker pulls
+imagePullSecrets: []
+
+serviceAccount:
+  # -- Force creation of a service account. Normally, no service account is
+  # used or mounted. If CloudSQL is enabled, a service account is always
+  # created regardless of this value.
+  create: false
+
+  # -- Annotations to add to the service account. If CloudSQL is in use, the
+  # annotation specifying the Google service account will also be added.
+  annotations: {}
+
+  # -- Name of the service account to use
+  # @default -- Name based on the fullname template
+  name: ""
+
+ingress:
+  # -- Whether to create an ingress
+  enabled: true
+
+  # -- Additional annotations to add to the ingress
+  annotations:
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=read:image"
+
+  # -- Hostname for the ingress. This should normally be the same as
+  # config.host.
+  host: ""
+
+  # -- Configures TLS for the ingress if needed. If multiple ingresses share
+  # the same hostname, only one of them needs a TLS configuration.
+  tls: []
+
+networkPolicy:
+  # -- Whether to restrict access to the image cutout service. Only enable if
+  # the ingress controller namespace is tagged with
+  # `gafaelfawr.lsst.io/ingress: "true"`.
+  enabled: false
+
+# -- Resource limits and requests for the vo-cutouts frontend pod
+resources: {}
+
+# -- Annotations for the vo-cutouts frontend pod
+podAnnotations: {}
+
+# -- Node selector rules for the vo-cutouts frontend pod
+nodeSelector: {}
+
+# -- Tolerations for the vo-cutouts frontend pod
+tolerations: []
+
+# -- Affinity rules for the vo-cutouts frontend pod
+affinity: {}
+
+# -- Path to the Vault secret (`secret/k8s_operator/<host>/vo-cutouts`, for
+# example)
+# @default -- None, must be set
+vaultSecretsPath: ""
+
+config:
+  # -- Configuration for the Butler repository to use
+  # @default -- None, must be set
+  butlerRepository: ""
+
+  # -- URL for the PostgreSQL database
+  # @default -- None, must be set
+  databaseUrl: ""
+
+  # -- Timeout for a single cutout job in seconds
+  # @default -- 600 (10 minutes)
+  timeout: 600
+
+  # -- Lifetime of job results in seconds
+  # @default -- 604800 (1 week)
+  lifetime: 604800
+
+  # -- Timeout for results from a sync cutout in seconds
+  # @default -- 60 (1 minute)
+  syncTimeout: 60
+
+  # -- Choose from the text form of Python logging levels
+  loglevel: "INFO"
+
+cloudsql:
+  # -- Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases
+  # on Google Cloud
+  enabled: false
+
+  image:
+    # -- Cloud SQL Auth Proxy image to use
+    repository: "gcr.io/cloudsql-docker/gce-proxy"
+
+    # -- Cloud SQL Auth Proxy tag to use
+    tag: "1.26.0-buster"
+
+    # -- Pull policy for Cloud SQL Auth Proxy images
+    pullPolicy: "IfNotPresent"
+
+  # -- Instance connection name for a CloudSQL PostgreSQL instance
+  instanceConnectionName: ""
+
+  # -- The Google service account that has an IAM binding to the `vo-cutouts`
+  # Kubernetes service accounts and has the `cloudsql.client` role
+  serviceAccount: ""
+
+cutoutWorker:
+  # -- Number of cutout worker pods to start
+  replicaCount: 1
+
+  image:
+    # -- Stack image to use for cutouts
+    repository: "lsstsqre/centos"
+
+    # -- Stack image tag to use
+    tag: "7-stack-lsst_distrib-w_2021_43"
+
+    # -- Pull policy for cutout workers
+    pullPolicy: "IfNotPresent"
+
+  # -- Resource limits and requests for the cutout worker pod
+  resources: {}
+
+  # -- Annotations for the cutout worker pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the cutout worker pod
+  nodeSelector: {}
+
+  # -- Tolerations for the cutout worker pod
+  tolerations: []
+
+  # -- Affinity rules for the cutout worker pod
+  affinity: {}
+
+databaseWorker:
+  # -- Number of database worker pods to start
+  replicaCount: 1
+
+  # -- Resource limits and requests for the database worker pod
+  resources: {}
+
+  # -- Annotations for the database worker pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the database worker pod
+  nodeSelector: {}
+
+  # -- Tolerations for the database worker pod
+  tolerations: []
+
+  # -- Affinity rules for the database worker pod
+  affinity: {}
+
+redis:
+  image:
+    # -- Redis image to use
+    repository: "redis"
+
+    # -- Redis image tag to use
+    tag: "6.2.6"
+
+    # -- Pull policy for the Redis image
+    pullPolicy: "IfNotPresent"
+
+  persistence:
+    # -- Whether to persist Redis storage and thus tokens. Setting this to
+    # false will use `emptyDir` and reset all tokens on every restart. Only
+    # use this for a test deployment.
+    enabled: true
+
+    # -- Amount of persistent storage to request
+    size: "100Mi"
+
+    # -- Class of storage to request
+    storageClass: ""
+
+    # -- Access mode of storage to request
+    accessMode: "ReadWriteOnce"
+
+    # -- Use an existing PVC, not dynamic provisioning. If this is set, the
+    # size, storageClass, and accessMode settings are ignored.
+    volumeClaimName: ""
+
+  # -- Pod annotations for the Redis pod
+  podAnnotations: {}
+
+  # -- Node selection rules for the Redis pod
+  nodeSelector: {}
+
+  # -- Tolerations for the Redis pod
+  tolerations: []
+
+  # -- Affinity rules for the Redis pod
+  affinity: {}


### PR DESCRIPTION
Add a new chart for the vo-cutouts service and its supporting Redis,
database worker, and cutout worker.  The cutout worker pod is based
on the stack container with Dramatiq and the cutout service deployed
dynamically on container start.

Add read:image to the Gafaelfawr list of known scopes, since it will
be used for access control for the vo-cutouts service.