### PR TITLE
[DM-32279] Refactor S3 Sink connector in kafka-connect-manager

### DIFF
--- a/charts/kafka-connect-manager/Chart.yaml
+++ b/charts/kafka-connect-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-connect-manager
-version: 0.9.3
+version: 0.9.4
 description: A Helm chart to deploy kafka connectors
 keywords:
   - Kafka, InfluxDB, S3, JDBC Sink, MirrorMaker 2
@@ -11,4 +11,4 @@ maintainers:
   - name: afausti
     email: afausti@lsst.org
     url: https://afausti.github.io/
-appVersion: 0.9.1
+appVersion: 0.9.3

--- a/charts/kafka-connect-manager/README.md
+++ b/charts/kafka-connect-manager/README.md
@@ -25,7 +25,7 @@ A Helm chart to deploy kafka connectors
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"lsstsqre/kafkaconnect"` |  |
 | image.tag | string | `"0.9.1"` |  |
-| influxdbSink.influxdb-sink | object | `{"autoUpdate":true,"checkInterval":"15000","connectInfluxDb":"","connectInfluxErrorPolicy":"THROW","connectInfluxMaxRetries":"10","connectInfluxRetryInterval":"60000","connectInfluxUrl":"http://localhost:8086","connectProgressEnabled":false,"enabled":false,"excludedTopicRegex":"","influxSecret":"","name":"influxdb-sink","tasksMax":1,"timestamp":"sys_time()","topicRegex":".*"}` | To create multiple instances of this connector repeat this block. The name of the instance, "influxdb-sink" in this case, is used as scope for the template variables. |
+| influxdbSink.influxdb-sink | object | `{"autoUpdate":true,"checkInterval":"15000","connectInfluxDb":"","connectInfluxErrorPolicy":"THROW","connectInfluxMaxRetries":"10","connectInfluxRetryInterval":"60000","connectInfluxUrl":"http://localhost:8086","connectProgressEnabled":false,"enabled":false,"excludedTopicRegex":"","influxSecret":"influxdb-auth","name":"influxdb-sink","tasksMax":1,"timestamp":"sys_time()","topicRegex":".*"}` | To create multiple instances of this connector repeat this block. The name of the instance, "influxdb-sink" in this case, is used as scope for the template variables. |
 | influxdbSink.influxdb-sink.autoUpdate | bool | `true` | If autoUpdate is enabled, check for new kafka topics. If they match topicRegex and excludedTopicRegex add them to the connector dynamically. |
 | influxdbSink.influxdb-sink.checkInterval | string | `"15000"` | The interval, in milliseconds, to check for new topics and update the connector. |
 | influxdbSink.influxdb-sink.connectInfluxDb | string | `""` | InfluxDB database to write to. |
@@ -36,7 +36,7 @@ A Helm chart to deploy kafka connectors
 | influxdbSink.influxdb-sink.connectProgressEnabled | bool | `false` | Enables the output for how many records have been processed. |
 | influxdbSink.influxdb-sink.enabled | bool | `false` | Whether this connector instance is deployed. |
 | influxdbSink.influxdb-sink.excludedTopicRegex | string | `""` | Regex to exclude topics from the list of selected topics from Kafka. |
-| influxdbSink.influxdb-sink.influxSecret | string | `""` | InfluxDB credentials. |
+| influxdbSink.influxdb-sink.influxSecret | string | `"influxdb-auth"` | Name of the kubernetes secret with InfluxDB credentials. |
 | influxdbSink.influxdb-sink.name | string | `"influxdb-sink"` | Name of the connector instance to create. |
 | influxdbSink.influxdb-sink.tasksMax | int | `1` | Number of Kafka Connect tasks. |
 | influxdbSink.influxdb-sink.timestamp | string | `"sys_time()"` | Timestamp to be used as the InfluxDB time, if not specified `sys_time()` is used. |
@@ -66,10 +66,9 @@ A Helm chart to deploy kafka connectors
 | mirrorMaker2.targetClusterBootstrapServers | string | `"localhost:31090"` | Destination Kafka cluster. |
 | mirrorMaker2.tasksMax | int | `1` | Number of Kafka Connect tasks. |
 | mirrorMaker2.topicRegex | string | `".*"` | Regex for selecting topics. Comma-separated lists are also supported. |
-| s3Sink.autoUpdate | bool | `true` | If autoUpdate is enabled, check for new kafka topics. If they match topicRegex and excludedTopicRegex add them to the connector dynamically. |
-| s3Sink.awsSecret | string | `""` | Kubernetes secret with the `aws_access_key_id` and `aws_secret_access_key` secret keys. |
+| s3Sink.awsSecret | string | `"aws-secret"` | Name of the Kubernetes secret with the `aws_access_key_id` and `aws_secret_access_key` keys. |
 | s3Sink.checkInterval | string | `"15000"` | The interval, in milliseconds, to check for new topics and update the connector. |
-| s3Sink.enabled | bool | `false` | Whether the Amazon S3 Sink connector is deployed. |
+| s3Sink.enabled | bool | `false` | Whether the Amazon S3 Sink connector is deployed. It is configured to use the Parquet format class with Snappy compression and a time based partitioner. |
 | s3Sink.excludedTopicRegex | string | `""` | Regex to exclude topics from the list of selected topics from Kafka. |
 | s3Sink.flushSize | string | `"1000"` | Number of records written to store before invoking file commits. |
 | s3Sink.locale | string | `"en-US"` | The locale to use when partitioning with TimeBasedPartitioner. |
@@ -79,12 +78,13 @@ A Helm chart to deploy kafka connectors
 | s3Sink.rotateIntervalMs | string | `"60000"` | The time interval in milliseconds to invoke file commits. |
 | s3Sink.s3BucketName | string | `""` | s3 bucket name. Must exist already. |
 | s3Sink.s3Region | string | `"us-east-1"` | s3 region |
+| s3Sink.s3SchemaCompatibility | string | `"NONE"` | s3 schema compatibility |
 | s3Sink.tasksMax | int | `1` | Number of Kafka Connect tasks. |
 | s3Sink.timestampExtractor | string | `"Record"` | The extractor determines how to obtain a timestamp from each record. |
 | s3Sink.timestampField | string | `"time"` | The record field to be used as timestamp by the timestamp extractor. Only applies if timestampExtractor is set to RecordField. |
 | s3Sink.timezone | string | `"UTC"` | The timezone to use when partitioning with TimeBasedPartitioner. |
-| s3Sink.topicRegex | string | `".*"` | Regex to select topics from Kafka. |
 | s3Sink.topicsDir | string | `"topics"` | Top level directory to store the data ingested from Kafka. |
+| s3Sink.topicsRegex | string | `".*"` | Regex to select topics from Kafka. |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/kafka-connect-manager/README.md
+++ b/charts/kafka-connect-manager/README.md
@@ -1,6 +1,6 @@
 # kafka-connect-manager
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![AppVersion: 0.9.1](https://img.shields.io/badge/AppVersion-0.9.1-informational?style=flat-square)
+![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![AppVersion: 0.9.3](https://img.shields.io/badge/AppVersion-0.9.3-informational?style=flat-square)
 
 A Helm chart to deploy kafka connectors
 

--- a/charts/kafka-connect-manager/templates/s3_sink.yaml
+++ b/charts/kafka-connect-manager/templates/s3_sink.yaml
@@ -1,4 +1,34 @@
 {{- if .Values.s3Sink.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.s3Sink.name }}
+data:
+  s3-sink-config.json: |+
+    {
+      "connector.class": "io.confluent.connect.s3.S3SinkConnector",
+      "flush.size": {{ .Values.s3Sink.flushSize | quote }}
+      "format.class": "io.confluent.connect.s3.format.parquet.ParquetFormat",
+      "locale": {{ .Values.s3Sink.locale | quote }},
+      "name": {{ .Values.s3Sink.name | quote }}
+      "parquet.codec": "snappy",
+      "partition.duration.ms": {{ .Values.s3Sink.partitionDurationMs | quote }},
+      "partitioner.class": "io.confluent.connect.storage.partitioner.TimeBasedPartitioner",
+      "path.format": {{ .Values.s3Sink.pathFormat | quote }}
+      "rotate.interval.ms": {{ .Values.s3Sink.rotateIntervalMs | quote }}
+      "s3.bucket.name": {{ .Values.s3Sink.s3BucketName | quote }},
+      "s3.region": {{ .Values.s3Sink.s3Region | quote }}
+      "s3.schema.compatibility": {{ .Values.s3Sink.s3SchemaCompatibility | quote }},
+      "storage.class": "io.confluent.connect.s3.storage.S3Storage",
+      "tasks.max": {{ .Values.s3Sink.tasksMax }},
+      "timestamp.extractor": {{ .Values.s3Sink.timestampExtractor }},
+      "timestamp.field": {{ .Values.s3Sink.timestampField }},
+      "timezone": {{ .Values.s3Sink.timezone }},
+      "topics.regex": {{ .Values.s3Sink.topicsRegex }},
+      "topics.dir": {{ .Values.s3Sink.topicsDir }}
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,16 +56,9 @@ spec:
         - kafkaconnect
         - create
         - s3-sink
-        {{- if .Values.s3Sink.autoUpdate }}
-        - --auto-update
-        {{- end }}
+        - --show-status
+        - /etc/s3-sink/s3-sink-config.json
         env:
-          - name: KAFKA_CONNECT_NAME
-            value: {{ .Values.s3Sink.name | quote }}
-          - name: KAFKA_CONNECT_S3_BUCKET_NAME
-            value: {{ .Values.s3Sink.s3BucketName | quote }}
-          - name: KAFKA_CONNECT_S3_REGION
-            value: {{ .Values.s3Sink.s3Region | quote }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
@@ -46,34 +69,15 @@ spec:
               secretKeyRef:
                 name: {{ .Values.s3Sink.awsSecret | quote }}
                 key: aws_secret_access_key
-          - name: KAFKA_CONNECT_S3_TOPICS_DIR
-            value: {{ .Values.s3Sink.topicsDir | quote }}
-          - name: KAFKA_CONNECT_S3_FLUSH_SIZE
-            value: {{ .Values.s3Sink.flushSize | quote }}
-          - name: KAFKA_CONNECT_S3_ROTATE_INTERVAL_MS
-            value: {{ .Values.s3Sink.rotateIntervalMs | quote }}
-          - name: KAFKA_CONNECT_S3_PARTITION_DURATION_MS
-            value: {{ .Values.s3Sink.partitionDurationMs | quote }}
-          - name: KAFKA_CONNECT_S3_PATH_FORMAT
-            value: {{ .Values.s3Sink.pathFormat | quote }}
-          - name: KAFKA_CONNECT_TASKS_MAX
-            value: {{ .Values.s3Sink.tasksMax | quote }}
-          - name: KAFKA_CONNECT_TOPIC_REGEX
-            value: {{ .Values.s3Sink.topicRegex | quote }}
-          - name: KAFKA_CONNECT_CHECK_INTERVAL
-            value: {{ .Values.s3Sink.checkInterval | quote  }}
-          - name: KAFKA_CONNECT_EXCLUDED_TOPIC_REGEX
-            value: {{ .Values.s3Sink.excludedTopicRegex | quote }}
-          - name: KAFKA_CONNECT_S3_LOCALE
-            value: {{ .Values.s3Sink.locale | quote }}
-          - name: KAFKA_CONNECT_S3_TIMEZONE
-            value: {{ .Values.s3Sink.timezone | quote }}
-          - name: KAFKA_CONNECT_TIMESTAMP_EXTRACTOR
-            value: {{ .Values.s3Sink.timestampExtractor | quote }}
-          - name: KAFKA_CONNECT_TIMESTAMP_FIELD
-            value: {{ .Values.s3Sink.timestampField | quote }}
           - name: KAFKA_BROKER_URL
             value: {{ .Values.env.kafkaBrokerUrl | quote }}
           - name: KAFKA_CONNECT_URL
             value: {{ .Values.env.kafkaConnectUrl | quote }}
+        volumeMounts:
+        - name: s3-sink
+          mountPath: /etc/s3-sink
+      volumes:
+      - name: s3-sink
+        configMap:
+          name: {{ .Values.s3Sink.name }}
 {{- end }}

--- a/charts/kafka-connect-manager/values.yaml
+++ b/charts/kafka-connect-manager/values.yaml
@@ -17,8 +17,8 @@ influxdbSink:
     connectInfluxUrl: "http://localhost:8086"
     # -- InfluxDB database to write to.
     connectInfluxDb: ""
-    # -- InfluxDB credentials.
-    influxSecret: ""
+    # -- Name of the kubernetes secret with InfluxDB credentials.
+    influxSecret: "influxdb-auth"
     # -- Number of Kafka Connect tasks.
     tasksMax: 1
     # -- Regex to select topics from Kafka.

--- a/charts/kafka-connect-manager/values.yaml
+++ b/charts/kafka-connect-manager/values.yaml
@@ -41,7 +41,7 @@ influxdbSink:
     connectProgressEnabled: false
 
 s3Sink:
-  # -- Whether the Amazon S3 Sink connector is deployed.
+  # -- Whether the Amazon S3 Sink connector is deployed. It is configured to use the Parquet format class with Snappy compression and a time based partitioner.
   enabled: false
   # -- Name of the connector to create.
   name: s3-sink
@@ -49,10 +49,12 @@ s3Sink:
   s3BucketName: ""
   # -- s3 region
   s3Region: "us-east-1"
+  # -- s3 schema compatibility
+  s3SchemaCompatibility: "NONE"
   # -- Top level directory to store the data ingested from Kafka.
   topicsDir: "topics"
-  # -- Kubernetes secret with the `aws_access_key_id` and `aws_secret_access_key` secret keys.
-  awsSecret: ""
+  # -- Name of the Kubernetes secret with the `aws_access_key_id` and `aws_secret_access_key` keys.
+  awsSecret: "aws-secret"
   # -- Number of records written to store before invoking file commits.
   flushSize: "1000"
   # -- The time interval in milliseconds to invoke file commits.
@@ -64,9 +66,7 @@ s3Sink:
   # -- Number of Kafka Connect tasks.
   tasksMax: 1
   # -- Regex to select topics from Kafka.
-  topicRegex: ".*"
-  # -- If autoUpdate is enabled, check for new kafka topics. If they match topicRegex and excludedTopicRegex add them to the connector dynamically.
-  autoUpdate: true
+  topicsRegex: ".*"
   # -- The interval, in milliseconds, to check for new topics and update the connector.
   checkInterval: "15000"
   # -- Regex to exclude topics from the list of selected topics from Kafka.


### PR DESCRIPTION
- Create a configmap with the s3-sink connector configuration and use kafkaconnect to upload it
- AWS secrets for the S3 bucket are injected in the environment
