### PR TITLE
[DM-32418] Use new datalink snippets by default

### DIFF
--- a/charts/cadc-tap/Chart.yaml
+++ b/charts/cadc-tap/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/lsst-sqre/lsst-tap-service
 maintainers:
   - name: cbanek
 name: cadc-tap
-version: 0.3.4
+version: 0.3.5

--- a/charts/cadc-tap/values.yaml
+++ b/charts/cadc-tap/values.yaml
@@ -20,7 +20,7 @@ qserv_host: "qserv-master01:4040"
 tap_schema_address: "tap-schema-db.tap-schema.svc.cluster.local:3306"
 
 # Datalink payload URL
-datalink_payload_url: "https://github.com/lsst/sdm_schemas/releases/download/1.1.1/datalink-snippets.zip"
+datalink_payload_url: "https://github.com/lsst/sdm_schemas/releases/download/1.1.2/datalink-snippets.zip"
 
 # Spin up a container to pretend to be QServ.
 use_mock_qserv: true


### PR DESCRIPTION
Bump chart version, set values.