### PR TITLE
[DM-32422] Update cert-issuer ClusterIssuer API

### DIFF
--- a/charts/cert-issuer/Chart.yaml
+++ b/charts/cert-issuer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cert-issuer
-version: 0.1.1
+version: 1.0.0
 description: Certificate issuer for Rubin Science Platform
 type: application
 maintainers:

--- a/charts/cert-issuer/README.md
+++ b/charts/cert-issuer/README.md
@@ -1,6 +1,6 @@
 # cert-issuer
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Certificate issuer for Rubin Science Platform
 

--- a/charts/cert-issuer/templates/cluster-issuer.yaml
+++ b/charts/cert-issuer/templates/cluster-issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: {{ include "cert-issuer.fullname" . }}-letsencrypt-dns
@@ -6,8 +6,8 @@ metadata:
     {{- include "cert-issuer.labels" . | nindent 4 }}
 spec:
   acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
     email: {{ required "config.email must be set" .Values.config.email | quote }}
+    server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: {{ include "cert-issuer.fullname" . }}-letsencrypt
     solvers:


### PR DESCRIPTION
cert-manager has dropped support for pre-v1 APIs, so update the
API of the ClusterIssuer to v1.  Bump the chart version number to
1.0.0 since it seems to be stable.  Regenerate the documentation.