### PR TITLE
DM-32351: alert-stream-broker: Correct the spec for Kafka storage class

### DIFF
--- a/charts/alert-stream-broker/Chart.yaml
+++ b/charts/alert-stream-broker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-stream-broker
-version: 1.0.0
+version: 1.0.1
 description: Kafka broker cluster for distributing alerts
 maintainers:
   - name: swnelson

--- a/charts/alert-stream-broker/templates/kafka.yaml
+++ b/charts/alert-stream-broker/templates/kafka.yaml
@@ -48,7 +48,7 @@ spec:
       - id: 0
         type: persistent-claim
         size: {{ .Values.kafka.storage.size }}
-        storageClassName: {{ .Values.kafka.storage.storageClassName }}
+        class: {{ .Values.kafka.storage.storageClassName }}
         deleteClaim: false
   zookeeper:
     replicas: {{ .Values.zookeeper.replicas }}
@@ -57,7 +57,7 @@ spec:
       # each will get its own PersistentVolumeClaim for the configured size.
       type: persistent-claim
       size: {{ .Values.zookeeper.storage.size }}
-      storageClassName: {{ .Values.zookeeper.storage.storageClassName }}
+      class: {{ .Values.zookeeper.storage.storageClassName }}
       deleteClaim: false
   entityOperator:
     topicOperator: {}


### PR DESCRIPTION
The schema for a Kafka resource's storage claims actually uses the key "class", not "storageClassName".