### PR TITLE
[DM-32576] Fine tune replicator configuration on stable

### DIFF
--- a/charts/kafka-connect-manager/Chart.yaml
+++ b/charts/kafka-connect-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-connect-manager
-version: 0.9.7
+version: 0.9.8
 description: A Helm chart to deploy kafka connectors
 keywords:
   - Kafka, InfluxDB Sink, S3 Sink, JDBC Sink, MirrorMaker 2

--- a/charts/kafka-connect-manager/README.md
+++ b/charts/kafka-connect-manager/README.md
@@ -1,6 +1,6 @@
 # kafka-connect-manager
 
-![Version: 0.9.7](https://img.shields.io/badge/Version-0.9.7-informational?style=flat-square) ![AppVersion: 0.9.3](https://img.shields.io/badge/AppVersion-0.9.3-informational?style=flat-square)
+![Version: 0.9.8](https://img.shields.io/badge/Version-0.9.8-informational?style=flat-square) ![AppVersion: 0.9.3](https://img.shields.io/badge/AppVersion-0.9.3-informational?style=flat-square)
 
 A Helm chart to deploy kafka connectors
 
@@ -57,6 +57,7 @@ A Helm chart to deploy kafka connectors
 | jdbcSink.tasksMax | string | `"10"` | Number of Kafka Connect tasks. |
 | jdbcSink.topicRegex | string | `".*"` | Regex for selecting topics. |
 | mirrorMaker2.enabled | bool | `false` | Whether the MirrorMaker 2 connectors (heartbeat, checkpoint and mirror-source) are deployed. |
+| mirrorMaker2.maxRequestSize | int | `26214400` | The max size of a request in bytes |
 | mirrorMaker2.name | string | `"replicator"` | Name od the connector to create. |
 | mirrorMaker2.replicationPolicySeparator | string | `"."` | Separator used to format the remote topic name. Use an empty string if sourceClusterAlias is empty. |
 | mirrorMaker2.sourceClusterAlias | string | `"src"` | Alias for the source cluster. The remote topic name is prefixed by this value. Use an empty string to preserve the name of the source topic in the destination cluster. |
@@ -69,7 +70,7 @@ A Helm chart to deploy kafka connectors
 | s3Sink.awsSecret | string | `"aws-secret"` | Name of the Kubernetes secret with the `aws_access_key_id` and `aws_secret_access_key` keys. |
 | s3Sink.behaviorOnNullValues | string | `"fail"` | How to handle records with a null value (for example, Kafka tombstone records). Valid options are ignore and fail. |
 | s3Sink.checkInterval | string | `"15000"` | The interval, in milliseconds, to check for new topics and update the connector. |
-| s3Sink.enabled | bool | `true` | Whether the Amazon S3 Sink connector is deployed. It is configured to use the Parquet format class with Snappy compression and a time based partitioner. |
+| s3Sink.enabled | bool | `false` | Whether the Amazon S3 Sink connector is deployed. It is configured to use the Parquet format class with Snappy compression and a time based partitioner. |
 | s3Sink.excludedTopicRegex | string | `""` | Regex to exclude topics from the list of selected topics from Kafka. |
 | s3Sink.flushSize | string | `"1000"` | Number of records written to store before invoking file commits. |
 | s3Sink.locale | string | `"en-US"` | The locale to use when partitioning with TimeBasedPartitioner. |

--- a/charts/kafka-connect-manager/templates/mirrormaker2.yaml
+++ b/charts/kafka-connect-manager/templates/mirrormaker2.yaml
@@ -39,7 +39,8 @@ data:
       "topics": {{ .Values.mirrorMaker2.topicRegex | quote }},
       "sync.topic.acls.enabled": {{ .Values.mirrorMaker2.syncTopicAclsEnabled | quote }},
       "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
-      "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter"
+      "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+      "max.request.size": {{ .Values.mirrorMaker2.maxRequestSize }}
     }
 ---
 apiVersion: apps/v1

--- a/charts/kafka-connect-manager/values.yaml
+++ b/charts/kafka-connect-manager/values.yaml
@@ -111,6 +111,8 @@ mirrorMaker2:
   tasksMax: 1
   # -- Whether to monitor source cluster ACLs for changes.
   syncTopicAclsEnabled: false
+  # -- The max size of a request in bytes
+  maxRequestSize: 26214400
 
 jdbcSink:
   # -- Whether the JDBC Sink connector is deployed.


### PR DESCRIPTION
Expose `max.request.size` configuration for Mirror Maker 2  in the Helm chart