### PR TITLE
[DM-32520] Update to Gafaelfawr 3.3.0

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.2.9
+version: 4.3.0
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:
   - name: rra
-appVersion: 3.2.1
+appVersion: 3.3.0

--- a/charts/gafaelfawr/README.md
+++ b/charts/gafaelfawr/README.md
@@ -1,6 +1,6 @@
 # gafaelfawr
 
-![Version: 4.2.9](https://img.shields.io/badge/Version-4.2.9-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
+![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
 
 The Gafaelfawr authentication and authorization system
 

--- a/charts/gafaelfawr/templates/service.yaml
+++ b/charts/gafaelfawr/templates/service.yaml
@@ -14,20 +14,3 @@ spec:
     {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: "frontend"
   sessionAffinity: None
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "gafaelfawr.fullname" . }}-service
-  labels:
-    {{- include "gafaelfawr.labels" . | nindent 4 }}
-spec:
-  type: ClusterIP
-  ports:
-    - protocol: "TCP"
-      port: 8080
-      targetPort: "http"
-  selector:
-    {{- include "gafaelfawr.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: "frontend"
-  sessionAffinity: None

--- a/charts/moneypenny/Chart.yaml
+++ b/charts/moneypenny/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 name: moneypenny
 maintainers:
   - name: athornton
-version: 0.1.1
+version: 0.1.2

--- a/charts/moneypenny/values.yaml
+++ b/charts/moneypenny/values.yaml
@@ -44,7 +44,7 @@ ingress:
   enabled: false
   annotations:
     nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=admin:provision"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?scope=admin:provision"
   hosts:
     - host: chart-example.local
       paths: ["/moneypenny"]


### PR DESCRIPTION
Also remove the old gafaelfawr-service definition in favor of the
service named gafaelfawr.  moneypenny and one Phalanx reference
were the only uses of the old name, both of which will be fixed as
part of this deployment.