### PR TITLE
DM-31978: Add alert-stream-simulator

### DIFF
--- a/charts/alert-stream-simulator/.helmignore
+++ b/charts/alert-stream-simulator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/alert-stream-simulator/Chart.yaml
+++ b/charts/alert-stream-simulator/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: alert-stream-simulator
+version: 1.0.0
+description: Producer which repeatedly publishes a static set of alerts into a Kafka topic
+maintainers:
+  - name: swnelson
+    email: swnelson@uw.edu
+appVersion: 1.0.0
+type: application

--- a/charts/alert-stream-simulator/README.md
+++ b/charts/alert-stream-simulator/README.md
@@ -1,0 +1,30 @@
+# alert-stream-simulator
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+
+Producer which repeatedly publishes a static set of alerts into a Kafka topic
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| swnelson | swnelson@uw.edu |  |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| clusterName | string | `"alert-broker"` | Name of a Strimzi Kafka cluster to connect to. |
+| clusterPort | int | `9092` | Port to connect to on the Strimzi Kafka cluster. It should be an internal TLS listener. |
+| fullnameOverride | string | `""` | Explicitly sets the full name used for the deployment and job (includes the release name). |
+| image.imagePullPolicy | string | `"IfNotPresent"` | Pull policy for the Deployment |
+| image.repository | string | `"swnelson/alert-stream-simulator"` | Source repository for the image which holds the rubin-alert-stream program. |
+| image.tag | string | `"latest"` | Tag to use for the rubin-alert-stream container. |
+| kafkaUserName | string | `"alert-stream-simulator"` | The username of the Kafka user identity used to connect to the broker. |
+| nameOverride | string | `""` | Explicitly sets the name of the deployment and job. |
+| repeatInterval | int | `37` | How often (in seconds) to repeat the sample data into the replay topic. |
+| replayTopicName | string | `"alerts-simulated"` | Name of the topic which will receive the repeated alerts on an interval. |
+| schemaID | int | `1` | Integer ID to use in the prefix of alert data packets. This should be a valid Confluent Schema Registry ID associated with the schema used. |
+| staticTopicName | string | `"alerts-static"` | Name of the topic which will hold a static single visit of sample data. |
+| strimziAPIVersion | string | `"v1beta2"` | API version of the Strimzi installation's custom resource definitions |
+

--- a/charts/alert-stream-simulator/templates/_helpers.tpl
+++ b/charts/alert-stream-simulator/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alertStreamSimulator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "alertStreamSimulator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "alertStreamSimulator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "alertStreamSimulator.labels" -}}
+helm.sh/chart: {{ include "alertStreamSimulator.chart" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "alertStreamSimulator.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "alertStreamSimulator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "alertStreamSimulator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/alert-stream-simulator/templates/deployment.yaml
+++ b/charts/alert-stream-simulator/templates/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "alertStreamSimulator.fullname" . }}
+  labels:
+    {{- include "alertStreamSimulator.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "alertStreamSimulator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "alertStreamSimulator.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: "alert-stream-simulator"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          volumeMounts:
+            - name: "kafka-client-secret"
+              mountPath: "/etc/kafka-client-secret"
+              readOnly: True
+            - name: "kafka-server-ca-cert"
+              mountPath: "/etc/kafka-server-ca-cert"
+              readOnly: True
+          command:
+            - "rubin-alert-sim"
+            - "--verbose"
+            - "play-stream"
+            - "--broker={{ .Values.clusterName }}-kafka-bootstrap:{{ .Values.clusterPort }}"
+            - "--dst-topic={{ .Values.replayTopicName }}"
+            - "--src-topic={{ .Values.staticTopicName }}"
+            - "--tls-client-key-location=/etc/kafka-client-secret/user.key"
+            - "--tls-client-crt-location=/etc/kafka-client-secret/user.crt"
+            - "--tls-server-ca-crt-location=/etc/kafka-server-ca-cert/ca.crt"
+            - "--repeat-interval={{ .Values.repeatInterval }}"
+      volumes:
+        - name: "kafka-client-secret"
+          secret:
+            secretName: "{{ .Values.kafkaUserName}}"
+        - name: "kafka-server-ca-cert"
+          secret:
+            secretName: "{{ .Values.clusterName}}-cluster-ca-cert"

--- a/charts/alert-stream-simulator/templates/kafka-topics.yaml
+++ b/charts/alert-stream-simulator/templates/kafka-topics.yaml
@@ -1,0 +1,23 @@
+apiVersion: "kafka.strimzi.io/{{ .Values.strimziAPIVersion }}"
+kind: KafkaTopic
+metadata:
+  name: "{{ .Values.staticTopicName }}"
+  labels:
+    strimzi.io/cluster: "{{ .Values.clusterName }}"
+spec:
+  partitions: 8
+  replicas: 1
+  config:
+    cleanup.policy: compact
+---
+apiVersion: "kafka.strimzi.io/{{ .Values.strimziAPIVersion }}"
+kind: KafkaTopic
+metadata:
+  name: "{{ .Values.replayTopicName }}"
+  labels:
+    strimzi.io/cluster: "{{ .Values.clusterName }}"
+spec:
+  partitions: 8
+  replicas: 2
+  config:
+    cleanup.policy: compact

--- a/charts/alert-stream-simulator/templates/kafka-user.yaml
+++ b/charts/alert-stream-simulator/templates/kafka-user.yaml
@@ -1,0 +1,45 @@
+apiVersion: kafka.strimzi.io/{{ .Values.strimziAPIVersion }}
+kind: KafkaUser
+metadata:
+  name: {{ .Values.kafkaUserName }}
+  labels:
+    strimzi.io/cluster: {{ .Values.clusterName }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Allow all operations on both topics
+      - resource:
+          type: topic
+          name: "{{ .Values.staticTopicName }}"
+          patternType: literal
+        operation: All
+        type: allow
+      - resource:
+          type: topic
+          name: "{{ .Values.replayTopicName }}"
+          patternType: literal
+        operation: All
+        type: allow
+      # Allow all on the __consumer_offsets topic
+      - resource:
+          type: topic
+          name: "__consumer_offsets"
+          patternType: literal
+        operation: All
+        type: allow
+      # Allow running as a consumer group
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operation: Describe
+        type: allow
+      - resource:
+          type: group
+          name: "*"
+          patternType: literal
+        operation: Read
+        type: allow

--- a/charts/alert-stream-simulator/templates/load-data-job.yaml
+++ b/charts/alert-stream-simulator/templates/load-data-job.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-load-data"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pre-install-job
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        volumeMounts:
+          - name: "kafka-client-secret"
+            mountPath: "/etc/kafka-client-secret"
+            readOnly: True
+          - name: "kafka-server-ca-cert"
+            mountPath: "/etc/kafka-server-ca-cert"
+            readOnly: True
+        command:
+          - "rubin-alert-sim"
+          - "--verbose"
+          - "create-stream"
+          - "--broker={{ .Values.clusterName }}-kafka-bootstrap:{{ .Values.clusterPort }}"
+          - "--dst-topic={{ .Values.staticTopicName }}"
+          - "--schema-id={{ .Values.schemaID }}"
+          - "--tls-client-key-location=/etc/kafka-client-secret/user.key"
+          - "--tls-client-crt-location=/etc/kafka-client-secret/user.crt"
+          - "--tls-server-ca-crt-location=/etc/kafka-server-ca-cert/ca.crt"
+          - "--force"
+          - "/var/sample_alert_data/rubin_single_visit_sample.avro"
+      volumes:
+        - name: "kafka-client-secret"
+          secret:
+            secretName: "{{ .Values.kafkaUserName}}"
+        - name: "kafka-server-ca-cert"
+          secret:
+            secretName: "{{ .Values.clusterName}}-cluster-ca-cert"

--- a/charts/alert-stream-simulator/values.yaml
+++ b/charts/alert-stream-simulator/values.yaml
@@ -1,0 +1,40 @@
+# -- Explicitly sets the name of the deployment and job.
+nameOverride: ""
+
+# -- Explicitly sets the full name used for the deployment and job (includes
+# the release name).
+fullnameOverride: ""
+
+# -- The username of the Kafka user identity used to connect to the broker.
+kafkaUserName: alert-stream-simulator
+
+# -- Name of the topic which will hold a static single visit of sample data.
+staticTopicName: alerts-static
+
+# -- Name of the topic which will receive the repeated alerts on an interval.
+replayTopicName: alerts-simulated
+
+# -- Integer ID to use in the prefix of alert data packets. This should be a
+# valid Confluent Schema Registry ID associated with the schema used.
+schemaID: 1
+
+# -- Name of a Strimzi Kafka cluster to connect to.
+clusterName: alert-broker
+
+# -- Port to connect to on the Strimzi Kafka cluster. It should be an internal
+# TLS listener.
+clusterPort: 9092
+
+# -- API version of the Strimzi installation's custom resource definitions
+strimziAPIVersion: v1beta2
+
+image:
+  # -- Source repository for the image which holds the rubin-alert-stream program.
+  repository: swnelson/alert-stream-simulator
+  # -- Tag to use for the rubin-alert-stream container.
+  tag: "latest"
+  # -- Pull policy for the Deployment
+  imagePullPolicy: IfNotPresent
+
+# -- How often (in seconds) to repeat the sample data into the replay topic.
+repeatInterval: 37

--- a/charts/alert-stream-simulator/values.yaml
+++ b/charts/alert-stream-simulator/values.yaml
@@ -30,9 +30,9 @@ strimziAPIVersion: v1beta2
 
 image:
   # -- Source repository for the image which holds the rubin-alert-stream program.
-  repository: swnelson/alert-stream-simulator
+  repository: lsstdm/alert-stream-simulator
   # -- Tag to use for the rubin-alert-stream container.
-  tag: "latest"
+  tag: v1.0.0
   # -- Pull policy for the Deployment
   imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
Adds a new alert-stream-simulator application which publishes a static set of alerts into Kafka.