### PR TITLE
alert-stream-simulator: use an argo hook, not a helm hook, for job

### DIFF
--- a/charts/alert-stream-simulator/Chart.yaml
+++ b/charts/alert-stream-simulator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-stream-simulator
-version: 1.1.2
+version: 1.2.0
 description: Producer which repeatedly publishes a static set of alerts into a Kafka topic
 maintainers:
   - name: swnelson

--- a/charts/alert-stream-simulator/templates/load-data-job.yaml
+++ b/charts/alert-stream-simulator/templates/load-data-job.yaml
@@ -8,9 +8,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    argocd.argoproj.io/hook: Sync
 spec:
   template:
     metadata:


### PR DESCRIPTION
Using a helm hook makes the job immediately disappear on success which makes it hard to get logs. Sync is more appropriate.