### PR TITLE
alert-stream-simulator: force recreation of static topic

### DIFF
--- a/charts/alert-stream-simulator/Chart.yaml
+++ b/charts/alert-stream-simulator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-stream-simulator
-version: 1.2.0
+version: 1.3.0
 description: Producer which repeatedly publishes a static set of alerts into a Kafka topic
 maintainers:
   - name: swnelson

--- a/charts/alert-stream-simulator/templates/kafka-topics.yaml
+++ b/charts/alert-stream-simulator/templates/kafka-topics.yaml
@@ -2,6 +2,10 @@ apiVersion: "kafka.strimzi.io/{{ .Values.strimziAPIVersion }}"
 kind: KafkaTopic
 metadata:
   name: {{ template "alertStreamSimulator.staticTopicName" . }}
+  annotations:
+    # The static topic should be deleted and replaced on every sync. This way,
+    # the job which loads data into it always has a clean slate.
+    argocd.argoproj.io/sync-options: Replace=true
   labels:
     strimzi.io/cluster: "{{ .Values.clusterName }}"
 spec:


### PR DESCRIPTION
Always delete and remake the static topic during an Argo sync so that it's always got a single copy of the simulated alert data.