### PR TITLE
DM-32778: alert-stream-simulator: create static topic via job, not resource

### DIFF
--- a/charts/alert-stream-simulator/Chart.yaml
+++ b/charts/alert-stream-simulator/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: alert-stream-simulator
-version: 1.4.0
+version: 1.5.0
 description: Producer which repeatedly publishes a static set of alerts into a Kafka topic
 maintainers:
   - name: swnelson
     email: swnelson@uw.edu
-appVersion: 1.1.0
+appVersion: 1.2.0
 type: application

--- a/charts/alert-stream-simulator/templates/_helpers.tpl
+++ b/charts/alert-stream-simulator/templates/_helpers.tpl
@@ -50,8 +50,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Versioned name for the static topic
+Name for the static alerts topic.
 */}}
-{{- define "alertStreamSimulator.staticTopicName" -}}
-{{ .Values.staticTopicName }}-rev-{{ .Release.Revision }}
-{{- end }}
+{{- define "alertStreamSimulator.staticTopicName" -}}alerts-static{{- end }}

--- a/charts/alert-stream-simulator/templates/kafka-topics.yaml
+++ b/charts/alert-stream-simulator/templates/kafka-topics.yaml
@@ -1,23 +1,6 @@
 apiVersion: "kafka.strimzi.io/{{ .Values.strimziAPIVersion }}"
 kind: KafkaTopic
 metadata:
-  name: {{ template "alertStreamSimulator.staticTopicName" . }}
-  annotations:
-    # The static topic should be deleted and replaced on every sync. This way,
-    # the job which loads data into it always has a clean slate.
-    argocd.argoproj.io/sync-options: Replace=true
-  labels:
-    strimzi.io/cluster: "{{ .Values.clusterName }}"
-spec:
-  partitions: 8
-  replicas: 2
-  config:
-    retention.ms: "-1" # infinite
-    retention.bytes: "-1"
----
-apiVersion: "kafka.strimzi.io/{{ .Values.strimziAPIVersion }}"
-kind: KafkaTopic
-metadata:
   name: "{{ .Values.replayTopicName }}"
   labels:
     strimzi.io/cluster: "{{ .Values.clusterName }}"

--- a/charts/alert-stream-simulator/templates/load-data-job.yaml
+++ b/charts/alert-stream-simulator/templates/load-data-job.yaml
@@ -35,6 +35,7 @@ spec:
           - "create-stream"
           - "--broker={{ .Values.clusterName }}-kafka-bootstrap:{{ .Values.clusterPort }}"
           - "--dst-topic={{ template "alertStreamSimulator.staticTopicName" . }}"
+          - "--create-topic"
           - "--schema-id={{ .Values.schemaID }}"
           - "--tls-client-key-location=/etc/kafka-client-secret/user.key"
           - "--tls-client-crt-location=/etc/kafka-client-secret/user.crt"

--- a/charts/alert-stream-simulator/values.yaml
+++ b/charts/alert-stream-simulator/values.yaml
@@ -32,7 +32,7 @@ image:
   # -- Source repository for the image which holds the rubin-alert-stream program.
   repository: lsstdm/alert-stream-simulator
   # -- Tag to use for the rubin-alert-stream container.
-  tag: v1.1.0
+  tag: v1.2.0
   # -- Pull policy for the Deployment
   imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
The Kafka topic that holds static alert data needs to be created de novo and
populated with a single pass of the sample alert data.

Populating it with data is done via a Kubernetes Job. This job runs on *every*
deployment of the simulator, which ensures that we're always using the latest
schema and alert data.

But it also means we need to delete the topic before filling it with data.
There is no clear way to signal this to Strimzi, so making it a Strimzi
KafkaTopic resource doesn't really work; instead, this revision uses a new
version of the stream simulator with configuration set to always create a new
topic, overwriting one if it already exists.