### PR TITLE
alert-stream-broker: don't set external bootstrap host

### DIFF
--- a/charts/alert-stream-broker/Chart.yaml
+++ b/charts/alert-stream-broker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-stream-broker
-version: 2.1.0
+version: 2.1.1
 description: Kafka broker cluster for distributing alerts
 maintainers:
   - name: swnelson

--- a/charts/alert-stream-broker/templates/kafka.yaml
+++ b/charts/alert-stream-broker/templates/kafka.yaml
@@ -47,10 +47,6 @@ spec:
             loadBalancerIP: {{ .Values.kafka.externalListener.bootstrap.ip }}
             {{- end }}
 
-            {{- if .Values.kafka.externalListener.bootstrap.host }}
-            host: {{ .Values.kafka.externalListener.bootstrap.host}}
-            {{- end }}
-
           {{- if .Values.kafka.externalListener.brokers }}
           brokers:
             {{- range $idx, $broker := .Values.kafka.externalListener.brokers }}


### PR DESCRIPTION
The Bootstrap listener is using a LoadBalancer type. This means it doesn't use the 'host' field, and Strimzi errors if you try.