### PR TITLE
alert-stream-simulator: fix types for very large int vals

### DIFF
--- a/charts/alert-stream-simulator/Chart.yaml
+++ b/charts/alert-stream-simulator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-stream-simulator
-version: 1.6.0
+version: 1.6.1
 description: Producer which repeatedly publishes a static set of alerts into a Kafka topic
 maintainers:
   - name: swnelson

--- a/charts/alert-stream-simulator/templates/kafka-topics.yaml
+++ b/charts/alert-stream-simulator/templates/kafka-topics.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     strimzi.io/cluster: "{{ .Values.clusterName }}"
 spec:
-  partitions: 8
-  replicas: 2
+  partitions: "{{ .Values.replayTopicPartitions }}"
+  replicas: {{ .Values.replayTopicReplicas }}
   config:
     cleanup.policy: "delete"
     retention.ms: "{{ .Values.maxMillisecondsRetained }}" # 7 days

--- a/charts/alert-stream-simulator/values.yaml
+++ b/charts/alert-stream-simulator/values.yaml
@@ -41,7 +41,12 @@ repeatInterval: 37
 
 # -- Maximum amount of time to save simulated alerts in the replay topic, in
 # milliseconds. Default is 7 days.
-maxMillisecondsRetained: 604800000
+maxMillisecondsRetained: "604800000"
 
-# -- Maximum number of bytes for the replay topic. Default is 3TB.
-maxBytesRetained: "3000000000000"
+# -- Maximum number of bytes for the replay topic, per partition, per replica.
+# Default is 100GB
+maxBytesRetained: "100000000000"
+
+replayTopicPartitions: 8
+
+replayTopicReplicas: 2


### PR DESCRIPTION
The integer `604800000` gets rendered as `6.048e+08` which breaks.