### PR TITLE
[DM-32811] Update to moneypenny 0.3.1

### DIFF
--- a/charts/moneypenny/Chart.yaml
+++ b/charts/moneypenny/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v2
-appVersion: "0.3.0"
+appVersion: "0.3.1"
 description: A Helm chart for Kubernetes
 name: moneypenny
 maintainers:
   - name: athornton
-version: 0.3.0
+  - name: rra
+version: 0.3.1

--- a/charts/moneypenny/README.md
+++ b/charts/moneypenny/README.md
@@ -1,6 +1,6 @@
 # moneypenny
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -9,6 +9,7 @@ A Helm chart for Kubernetes
 | Name | Email | Url |
 | ---- | ------ | --- |
 | athornton |  |  |
+| rra |  |  |
 
 ## Values
 

--- a/charts/moneypenny/templates/deployment.yaml
+++ b/charts/moneypenny/templates/deployment.yaml
@@ -78,9 +78,6 @@ spec:
         - name: "podinfo"
           downwardAPI:
             items:
-              - path: "labels"
-                fieldRef:
-                  fieldPath: "metadata.labels"
               - path: "name"
                 fieldRef:
                   fieldPath: "metadata.name"


### PR DESCRIPTION
Fixes the scheme of redirects and therefore passing of the
Authorization header to the request for commissioning status.