### PR TITLE
[DM-32991] Update all Ingresses, fix NetworkPolicies

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cachemachine
-version: 1.1.0
+version: 1.1.1
 description: Service to prepull Docker images for the Science Platform
 maintainers:
   - name: cbanek

--- a/charts/cachemachine/templates/ingress.yaml
+++ b/charts/cachemachine/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -16,9 +16,12 @@ spec:
       http:
         paths:
           - path: "/cachemachine"
+            pathType: "Prefix"
             backend:
-              serviceName: {{ template "cachemachine.fullname" . }}
-              servicePort: 80
+              service:
+                name: {{ template "cachemachine.fullname" . }}
+                port:
+                  number: 80
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/cadc-tap-postgres/Chart.yaml
+++ b/charts/cadc-tap-postgres/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/lsst-sqre/tap-postgres
 name: cadc-tap-postgres
 maintainers:
   - name: cbanek
-version: 0.1.3
+version: 0.1.4

--- a/charts/cadc-tap-postgres/templates/tap-ingress-anonymous.yaml
+++ b/charts/cadc-tap-postgres/templates/tap-ingress-anonymous.yaml
@@ -7,18 +7,18 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
     nginx.ingress.kubernetes.io/rewrite-target: "/tap/$1"
-{{ if .Values.ingress.ssl }}
+    {{- if .Values.ingress.ssl }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
     nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/obstap/"
-{{ else }}
+    {{- else }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
     nginx.ingress.kubernetes.io/proxy-redirect-to: "http://$host/api/obstap/"
-{{ end }}
-{{ if .Values.ingress.anonymous_annotations }}
+    {{- end }}
+{{- if .Values.ingress.anonymous_annotations }}
 {{ toYaml .Values.ingress.anonymous_annotations | indent 4}}
-{{ end }}
+{{- end }}
   name: {{ template "cadc-tap-postgres.fullname" . }}-anonymous-ingress
 spec:
   rules:
@@ -30,14 +30,23 @@ spec:
 {{ end }}
       paths:
       - backend:
-          serviceName: {{ template "cadc-tap-postgres.fullname" . }}-tap-server
-          servicePort: 8080
+          service:
+            name: {{ template "cadc-tap-postgres.fullname" . }}-tap-server
+            port:
+              number: 8080
         path: /api/obstap/(availability)
+        pathType: "ImplementationSpecific"
       - backend:
-          serviceName: {{ template "cadc-tap-postgres.fullname" . }}-tap-server
-          servicePort: 8080
+          service:
+            name: {{ template "cadc-tap-postgres.fullname" . }}-tap-server
+            port:
+              number: 8080
         path: /api/obstap/(capabilities)
+        pathType: "ImplementationSpecific"
       - backend:
-          serviceName: {{ template "cadc-tap-postgres.fullname" . }}-tap-server
-          servicePort: 8080
+          service:
+            name: {{ template "cadc-tap-postgres.fullname" . }}-tap-server
+            port:
+              number: 8080
         path: /api/obstap/(swagger-ui.*)
+        pathType: "ImplementationSpecific"

--- a/charts/cadc-tap-postgres/templates/tap-ingress-authenticated.yaml
+++ b/charts/cadc-tap-postgres/templates/tap-ingress-authenticated.yaml
@@ -7,18 +7,18 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
     nginx.ingress.kubernetes.io/rewrite-target: "/tap/$2"
-{{ if .Values.ingress.ssl }}
+    {{- if .Values.ingress.ssl }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
     nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/obstap/"
-{{ else }}
+    {{- else }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
     nginx.ingress.kubernetes.io/proxy-redirect-to: "http://$host/api/obstap/"
-{{ end }}
-{{ if .Values.ingress.authenticated_annotations }}
+    {{- end }}
+{{- if .Values.ingress.authenticated_annotations }}
 {{ toYaml .Values.ingress.authenticated_annotations | indent 4 }}
-{{ end }}
+{{- end }}
   name: {{ template "cadc-tap-postgres.fullname" . }}-authenticated-ingress
 spec:
   rules:
@@ -30,6 +30,9 @@ spec:
 {{ end }}
       paths:
       - backend:
-          serviceName: {{ template "cadc-tap-postgres.fullname" . }}-tap-server
-          servicePort: 8080
+          service:
+            name: {{ template "cadc-tap-postgres.fullname" . }}-tap-server
+            port:
+              number: 8080
         path: /api/obstap(/|$)(.*)
+        pathType: "ImplementationSpecific"

--- a/charts/cadc-tap/Chart.yaml
+++ b/charts/cadc-tap/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/lsst-sqre/lsst-tap-service
 maintainers:
   - name: cbanek
 name: cadc-tap
-version: 0.3.7
+version: 0.3.8

--- a/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-anonymous.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -7,18 +7,18 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
     nginx.ingress.kubernetes.io/rewrite-target: "/tap/$1"
-{{ if .Values.ingress.ssl }}
+    {{- if .Values.ingress.ssl }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
     nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/tap/"
-{{ else }}
+    {{- else }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
     nginx.ingress.kubernetes.io/proxy-redirect-to: "http://$host/api/tap/"
-{{ end }}
-{{ if .Values.ingress.anonymous_annotations }}
+    {{- end }}
+{{- if .Values.ingress.anonymous_annotations }}
 {{ toYaml .Values.ingress.anonymous_annotations | indent 4}}
-{{ end }}
+{{- end }}
   name: {{ template "cadc-tap.fullname" . }}-anonymous-ingress
 spec:
   rules:
@@ -30,14 +30,23 @@ spec:
 {{ end }}
       paths:
       - backend:
-          serviceName: {{ template "cadc-tap.fullname" . }}-tap-server
-          servicePort: 8080
+          service:
+            name: {{ template "cadc-tap.fullname" . }}-tap-server
+            port:
+              number: 8080
         path: /api/tap/(availability)
+        pathType: "ImplementationSpecific"
       - backend:
-          serviceName: {{ template "cadc-tap.fullname" . }}-tap-server
-          servicePort: 8080
+          service:
+            name: {{ template "cadc-tap.fullname" . }}-tap-server
+            port:
+              number: 8080
         path: /api/tap/(capabilities)
+        pathType: "ImplementationSpecific"
       - backend:
-          serviceName: {{ template "cadc-tap.fullname" . }}-tap-server
-          servicePort: 8080
+          service:
+            name: {{ template "cadc-tap.fullname" . }}-tap-server
+            port:
+              number: 8080
         path: /api/tap/(swagger-ui.*)
+        pathType: "ImplementationSpecific"

--- a/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
+++ b/charts/cadc-tap/templates/tap-ingress-authenticated.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -7,18 +7,18 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
     nginx.ingress.kubernetes.io/rewrite-target: "/tap/$2"
-{{ if .Values.ingress.ssl }}
+    {{- if .Values.ingress.ssl }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
     nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$host/api/tap/"
-{{ else }}
+    {{- else }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-redirect-from: "http://$host/tap/"
     nginx.ingress.kubernetes.io/proxy-redirect-to: "http://$host/api/tap/"
-{{ end }}
-{{ if .Values.ingress.authenticated_annotations }}
+    {{- end }}
+{{- if .Values.ingress.authenticated_annotations }}
 {{ toYaml .Values.ingress.authenticated_annotations | indent 4 }}
-{{ end }}
+{{- end }}
   name: {{ template "cadc-tap.fullname" . }}-authenticated-ingress
 spec:
   rules:
@@ -30,6 +30,9 @@ spec:
 {{ end }}
       paths:
       - backend:
-          serviceName: {{ template "cadc-tap.fullname" . }}-tap-server
-          servicePort: 8080
+          service:
+            name: {{ template "cadc-tap.fullname" . }}-tap-server
+            port:
+              number: 8080
         path: /api/tap(/|$)(.*)
+        pathType: "ImplementationSpecific"

--- a/charts/datalinker/Chart.yaml
+++ b/charts/datalinker/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.0.0
 description: A Helm chart for Kubernetes
 name: datalinker
 type: application
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: cbanek

--- a/charts/datalinker/templates/ingress.yaml
+++ b/charts/datalinker/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "datalinker.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -18,18 +18,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
-    - host: {{ required "Host not set" .Values.ingress.host | quote }}
+    - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}
-            {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
+            pathType: {{ default "Prefix" .Values.ingress.pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ .Values.service.port }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .Values.service.port }}
 {{- end }}

--- a/charts/exposurelog/Chart.yaml
+++ b/charts/exposurelog/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.31
+version: 0.1.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/exposurelog/templates/ingress.yaml
+++ b/charts/exposurelog/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "exposurelog.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,9 +29,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: "Prefix"
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -5,4 +5,4 @@ name: firefly
 home: "https://github.com/lsst/suit"
 maintainers:
   - name: cbanek
-version: 0.3.6
+version: 0.3.7

--- a/charts/firefly/templates/ingress.yaml
+++ b/charts/firefly/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "firefly.fullname" . }}
@@ -29,6 +29,9 @@ spec:
 {{ end }}
       paths:
       - path: "/portal/app(/|$)(.*)"
+        pathType: "ImplementationSpecific"
         backend:
-          serviceName: {{ include "firefly.fullname" . }}
-          servicePort: 8080
+          service:
+            name: {{ include "firefly.fullname" . }}
+            port:
+              number: 8080

--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.4.2
+version: 4.4.3
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:

--- a/charts/gafaelfawr/templates/ingress-rewrite.yaml
+++ b/charts/gafaelfawr/templates/ingress-rewrite.yaml
@@ -1,9 +1,4 @@
-{{- /*
-  Revert 3d0f5a89831d5c05f8d384031df6074fb6287e67 when Argo CD has been
-  fixed to pass in cluster capabilities, or when all clusters are running
-  Kubernetes 1.19 or later.
-*/ -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -26,6 +21,9 @@ spec:
     {{- end }}
         paths:
           - path: "/auth/tokens/id/.*"
+            pathType: "ImplementationSpecific"
             backend:
-              serviceName: {{ template "gafaelfawr.fullname" . }}
-              servicePort: 8080
+              service:
+                name: {{ template "gafaelfawr.fullname" . }}
+                port:
+                  number: 8080

--- a/charts/gafaelfawr/templates/ingress.yaml
+++ b/charts/gafaelfawr/templates/ingress.yaml
@@ -1,9 +1,4 @@
-{{- /*
-  Revert 3d0f5a89831d5c05f8d384031df6074fb6287e67 when Argo CD has been
-  fixed to pass in cluster capabilities, or when all clusters are running
-  Kubernetes 1.19 or later.
-*/ -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -24,30 +19,48 @@ spec:
     {{- end }}
         paths:
           - path: "/auth"
+            pathType: Prefix
             backend:
-              serviceName: {{ template "gafaelfawr.fullname" . }}
-              servicePort: 8080
+              service:
+                name: {{ template "gafaelfawr.fullname" . }}
+                port:
+                  number: 8080
           - path: "/login"
+            pathType: Exact
             backend:
-              serviceName: {{ template "gafaelfawr.fullname" . }}
-              servicePort: 8080
+              service:
+                name: {{ template "gafaelfawr.fullname" . }}
+                port:
+                  number: 8080
           - path: "/logout"
+            pathType: Exact
             backend:
-              serviceName: {{ template "gafaelfawr.fullname" . }}
-              servicePort: 8080
+              service:
+                name: {{ template "gafaelfawr.fullname" . }}
+                port:
+                  number: 8080
           - path: "/oauth2/callback"
+            pathType: Exact
             backend:
-              serviceName: {{ template "gafaelfawr.fullname" . }}
-              servicePort: 8080
+              service:
+                name: {{ template "gafaelfawr.fullname" . }}
+                port:
+                  number: 8080
           - path: "/.well-known/jwks.json"
+            pathType: Exact
             backend:
-              serviceName: {{ template "gafaelfawr.fullname" . }}
-              servicePort: 8080
+              service:
+                name: {{ template "gafaelfawr.fullname" . }}
+                port:
+                  number: 8080
           {{- if .Values.config.oidcServer.enabled }}
           - path: "/.well-known/openid-configuration"
+            pathType: Exact
             backend:
-              serviceName: {{ template "gafaelfawr.fullname" . }}
-              servicePort: 8080
+              service:
+                name: {{ template "gafaelfawr.fullname" . }}
+                port:
+                  number: 8080
           {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/mobu/Chart.yaml
+++ b/charts/mobu/Chart.yaml
@@ -4,5 +4,5 @@ home: https://github.com/lsst-sqre/mobu
 maintainers:
   - name: cbanek
 name: mobu
-version: 3.1.0
+version: 3.1.1
 appVersion: 4.1.0

--- a/charts/mobu/templates/ingress.yaml
+++ b/charts/mobu/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -16,9 +16,12 @@ spec:
       http:
         paths:
           - path: "/mobu"
+            pathType: "Prefix"
             backend:
-              serviceName: {{ template "mobu.fullname" . }}
-              servicePort: 80
+              service:
+                name: {{ template "mobu.fullname" . }}
+                port:
+                  number: 80
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/noteburst/Chart.yaml
+++ b/charts/noteburst/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/noteburst/templates/ingress.yaml
+++ b/charts/noteburst/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "noteburst.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -43,19 +32,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/semaphore/Chart.yaml
+++ b/charts/semaphore/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/semaphore/templates/ingress.yaml
+++ b/charts/semaphore/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "semaphore.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -43,19 +32,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/sherlock/Chart.yaml
+++ b/charts/sherlock/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 0.1.1
 description: A Helm chart for Kubernetes
 name: sherlock
 type: application
-version: 0.1.1
+version: 0.1.2
 maintainers:
   - name: cbanek

--- a/charts/sherlock/templates/ingress.yaml
+++ b/charts/sherlock/templates/ingress.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "sherlock.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
     {{- include "sherlock.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery -}}
@@ -15,21 +14,22 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
     nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.gafaelfawrAuthQuery }}"
     {{- end }}
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
-    - host: {{ required "Host not set" .Values.ingress.host | quote }}
+    - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}
-            {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
+            pathType: {{ default "Prefix" .Values.ingress.pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ .Values.service.port }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .Values.service.port }}
 {{- end }}

--- a/charts/sherlock/templates/networkpolicy.yaml
+++ b/charts/sherlock/templates/networkpolicy.yaml
@@ -2,20 +2,22 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "sherlock.fullname" . }}-networkpolicy
+  name: {{ include "sherlock.fullname" . }}
 spec:
   podSelector:
     matchLabels:
       {{- include "sherlock.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
-    - Egress
   ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
     - from:
-        - podSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              {{- include "sherlock.selectorLabels" . | nindent 14 }}
+              gafaelfawr.lsst.io/ingress: "true"
       ports:
-        - protocol: TCP
+        - protocol: "TCP"
           port: {{ .Values.service.port }}
 {{- end }}

--- a/charts/squareone/Chart.yaml
+++ b/charts/squareone/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # time you make changes to the chart and its templates, including the app
 # version.  Versions are expected to follow Semantic Versioning
 # (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the

--- a/charts/squareone/templates/ingress.yaml
+++ b/charts/squareone/templates/ingress.yaml
@@ -1,21 +1,17 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "squareone.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
     {{- include "squareone.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- if .Values.ingress.tls }}
   tls:
@@ -32,7 +28,10 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
   {{- end }}

--- a/charts/squash-api/Chart.yaml
+++ b/charts/squash-api/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: squash-api
-version: 0.1.5
+version: 0.1.6
 description: A Helm chart to deploy the SQuaSH API
 keywords:
   - SQuaSH, Metrics, InfluxDB, Chronograf, S3

--- a/charts/squash-api/templates/ingress.yaml
+++ b/charts/squash-api/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "squash-api.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: "Prefix"
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/times-square/Chart.yaml
+++ b/charts/times-square/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The chart version.
-version: 0.1.1
+version: 0.1.2
 
 # The app's version corresponding to the image tag.
 appVersion: "0.1.0"

--- a/charts/times-square/templates/ingress.yaml
+++ b/charts/times-square/templates/ingress.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "times-square.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
     {{- include "times-square.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery -}}
@@ -15,21 +14,22 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
     nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.gafaelfawrAuthQuery }}"
     {{- end }}
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
-    - host: {{ required "Host not set" .Values.ingress.host | quote }}
+    - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}
-            {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
+            pathType: {{ default "Prefix" .Values.ingress.pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ .Values.service.port }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .Values.service.port }}
 {{- end }}

--- a/charts/times-square/templates/networkpolicy.yaml
+++ b/charts/times-square/templates/networkpolicy.yaml
@@ -2,20 +2,22 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "times-square.fullname" . }}-networkpolicy
+  name: {{ include "times-square.fullname" . }}
 spec:
   podSelector:
     matchLabels:
       {{- include "times-square.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
-    - Egress
   ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
     - from:
-        - podSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              {{- include "times-square.selectorLabels" . | nindent 14 }}
+              gafaelfawr.lsst.io/ingress: "true"
       ports:
-        - protocol: TCP
+        - protocol: "TCP"
           port: {{ .Values.service.port }}
 {{- end }}

--- a/charts/vo-cutouts/Chart.yaml
+++ b/charts/vo-cutouts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vo-cutouts
-version: 0.1.3
+version: 0.1.4
 description: Image cutout service complying with IVOA SODA
 home: https://github.com/lsst-sqre/vo-cutouts
 maintainers:

--- a/charts/vo-cutouts/templates/ingress.yaml
+++ b/charts/vo-cutouts/templates/ingress.yaml
@@ -1,8 +1,4 @@
-{{- /*
-  Update apiVersion when Argo CD has been fixed to pass in cluster
-  capabilities, or when all clusters are running Kubernetes 1.19 or later.
-*/ -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -24,9 +20,12 @@ spec:
       http:
         paths:
           - path: "/api/cutout(.*)"
+            pathType: "ImplementationSpecific"
             backend:
-              serviceName: {{ template "vo-cutouts.fullname" . }}
-              servicePort: 8080
+              service:
+                name: {{ template "vo-cutouts.fullname" . }}
+                port:
+                  number: 8080
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/vo-cutouts/templates/networkpolicy.yaml
+++ b/charts/vo-cutouts/templates/networkpolicy.yaml
@@ -14,7 +14,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # Allow inbound access to Redis from pods (in any namespace) labeled
+    # Allow inbound access from pods (in any namespace) labeled
     # gafaelfawr.lsst.io/ingress: true.
     - from:
         - namespaceSelector: {}

--- a/rsp-starter/templates/ingress.yaml
+++ b/rsp-starter/templates/ingress.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
     {{- include "<CHARTNAME>.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
     {{- if .Values.ingress.gafaelfawrAuthQuery -}}
@@ -15,21 +14,23 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
     nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.gafaelfawrAuthQuery }}"
     {{- end }}
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
-    - host: {{ required "Host not set" .Values.ingress.host | quote }}
+    - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}
-            {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .Values.ingress.pathType }}
+            pathType: {{ default "Prefix" .Values.ingress.pathType }}
             {{- end }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ .Values.service.port }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .Values.service.port }}
 {{- end }}

--- a/rsp-starter/templates/networkpolicy.yaml
+++ b/rsp-starter/templates/networkpolicy.yaml
@@ -2,20 +2,22 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "<CHARTNAME>.fullname" . }}-networkpolicy
+  name: {{ include "<CHARTNAME>.fullname" . }}
 spec:
   podSelector:
     matchLabels:
       {{- include "<CHARTNAME>.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
-    - Egress
   ingress:
+    # Allow inbound access from pods (in any namespace) labeled
+    # gafaelfawr.lsst.io/ingress: true.
     - from:
-        - podSelector:
+        - namespaceSelector: {}
+          podSelector:
             matchLabels:
-              {{- include "<CHARTNAME>.selectorLabels" . | nindent 14 }}
+              gafaelfawr.lsst.io/ingress: "true"
       ports:
-        - protocol: TCP
+        - protocol: "TCP"
           port: {{ .Values.service.port }}
 {{- end }}


### PR DESCRIPTION
Update all Ingress objects to networking.k8s.io/v1.  This is the
only supported API in Kubernetes 1.22 and later, and in ingress-nginx
4.0 and later.  We are dropping support for Kubernetes versions
prior to 1.18, when this API was added.

Fix the NetworkPolicy created by the rsp-starter to restrict access
except from the NGINX ingress as intended, and fix all the
NetworkPolicy objects created from that template.  The prior version
was intended for use with a Redis rather than a web application.
