### PR TITLE
DM-32643: alert-database: fix podspec field name

### DIFF
--- a/charts/alert-database/Chart.yaml
+++ b/charts/alert-database/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-database
-version: 1.0.1
+version: 1.0.2
 description: Archival database of alerts sent through the alert stream.
 maintainers:
   - name: swnelson

--- a/charts/alert-database/templates/ingester-deployment.yaml
+++ b/charts/alert-database/templates/ingester-deployment.yaml
@@ -45,4 +45,4 @@ spec:
         - name: "kafka-server-ca-cert"
           secret:
             secretName: "{{ .Values.ingester.kafka.cluster}}-cluster-ca-cert"
-      serviceAccountNane: "{{ .Values.ingester.serviceAccountName }}"
+      serviceAccountName: "{{ .Values.ingester.serviceAccountName }}"


### PR DESCRIPTION
It's 'serviceAccountName', not 'serviceAccountNane'