### PR TITLE
DM-32644: alert-database: add frontend HTTP server

### DIFF
--- a/charts/alert-database/Chart.yaml
+++ b/charts/alert-database/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-database
-version: 1.1.0
+version: 2.0.0
 description: Archival database of alerts sent through the alert stream.
 maintainers:
   - name: swnelson

--- a/charts/alert-database/ci/values-idfint.yaml
+++ b/charts/alert-database/ci/values-idfint.yaml
@@ -1,12 +1,24 @@
 ingester:
   schemaRegistryURL: https://alert-schemas-int.lsst.cloud
 
+  serviceAccountName: alert-database-writer
+
   gcp:
-    serviceAccountName: alert-database-writer
+    serviceAccountName: alertdb-writer
     projectID: science-platform-int-dc5d
 
 storage:
   gcp:
     project: science-platform-int-dc5d
-    alertBucket: alertdb-packets
-    schemaBucket: alertdb-schemas
+    alertBucket: rubin-alertdb-int-us-central1-packets
+    schemaBucket: rubin-alertdb-int-us-central1-schemas
+
+ingress:
+  host: data-int.lsst.cloud
+
+server:
+  serviceAccountName: alert-database-reader
+
+  gcp:
+    serviceAccountName: alertdb-reader
+    projectID: science-platform-int-dc5d

--- a/charts/alert-database/templates/_helpers.tpl
+++ b/charts/alert-database/templates/_helpers.tpl
@@ -1,5 +1,27 @@
 {{/* -*- go-template -*- */}}
 
+{{- define "alertDatabase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "alertDatabase.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}
@@ -10,6 +32,11 @@ Create chart name and version as used by the chart label.
 {{/* Name for the ingester */}}
 {{- define "alertDatabase.ingesterName" -}}
 {{- printf "%s-ingester-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Name for the server */}}
+{{- define "alertDatabase.serverName" -}}
+{{- printf "%s-server-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -26,5 +53,13 @@ Ingester selector labels
 */}}
 {{- define "alertDatabase.ingesterSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "alertDatabase.ingesterName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Server selector labels
+*/}}
+{{- define "alertDatabase.serverSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "alertDatabase.serverName" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/alert-database/templates/ingress.yaml
+++ b/charts/alert-database/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/app-root: {{ .Values.ingress.path | quote }}
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?{{ required "ingress.gafaelfawrAuthQuery must be set" .Values.ingress.gafaelfawrAuthQuery }}"
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "alertDatabase.fullname" . }}
+  labels:
+    {{- include "alertDatabase.labels" . | nindent 4 }}
+spec:
+  rules:
+    - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path | quote }}
+            backend:
+              service:
+                name: {{ template "alertDatabase.fullname" . }}
+                port:
+                  name: http
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/alert-database/templates/ingress.yaml
+++ b/charts/alert-database/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/charts/alert-database/templates/server-deployment.yaml
+++ b/charts/alert-database/templates/server-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: {{ template "alertDatabase.serverName" . }}
+  labels:
+    {{- include "alertDatabase.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "alertDatabase.serverSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "alertDatabase.serverSelectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: "alert-database-server"
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+
+          command:
+            - "alertdb"
+            - "--listen-host=0.0.0.0"
+            - "--listen-port=3000"
+            - "--backend=google-cloud"
+            - "--gcp-project={{ required "A GCP project is required " .Values.storage.gcp.project }}"
+            - "--gcp-bucket-alerts={{ required "A GCP bucket name is required " .Values.storage.gcp.alertBucket }}"
+            - "--gcp-bucket-schemas={{ required "A GCP bucket name is required " .Values.storage.gcp.schemaBucket }}"
+            {{- if eq .Values.ingester.logLevel "debug" }}
+            - "--debug"
+            {{- end }}
+            {{- if eq .Values.ingester.logLevel "verbose" }}
+            - "--verbose"
+            {{- end }}
+
+
+      serviceAccountName: "{{ .Values.server.serviceAccountName }}"

--- a/charts/alert-database/templates/server-serviceaccount.yaml
+++ b/charts/alert-database/templates/server-serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.server.serviceAccountName }}
+  annotations:
+    # The following annotation connects the Kubernetes ServiceAccount to a GCP
+    # IAM Service Account, granting access to resources on GCP, via the
+    # "Workload Identity" framework.
+    #
+    # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+    iam.gke.io/gcp-service-account: "{{ .Values.server.gcp.serviceAccountName }}@{{ .Values.server.gcp.projectID }}.iam.gserviceaccount.com"

--- a/charts/alert-database/templates/service.yaml
+++ b/charts/alert-database/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alertDatabase.fullname" . }}
+  labels:
+    {{- include "alertDatabase.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.server.service.type }}
+  ports:
+    - port: {{ .Values.server.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "alertDatabase.serverSelectorLabels" . | nindent 4 }}

--- a/charts/alert-database/values.yaml
+++ b/charts/alert-database/values.yaml
@@ -1,3 +1,9 @@
+# -- Override the base name for resources
+nameOverride: ""
+
+# -- Override the full name for resources (includes the release name)
+fullnameOverride: ""
+
 # Configuration for the ingester, which pulls data out of Kafka and writes
 # it to the database backend.
 
@@ -42,6 +48,32 @@ ingester:
   # anything else to suppress logging.
   logLevel: verbose
 
+server:
+  image:
+    repository: lsstdm/alert_database_server
+    tag: v2.1.0
+    imagePullPolicy: IfNotPresent
+
+  gcp:
+    # -- Name of a service account which has credentials granting access to the
+    # alert database's backing storage buckets.
+    serviceAccountName: ""
+    # -- Project ID which has the above GCP IAM service account
+    projectID: ""
+
+  # -- The name of the Kubernetes ServiceAccount (*not* the Google Cloud IAM
+  # service account!) which is used by the alert database server.
+  serviceAccountName: alertdb-reader
+
+  # -- set the log level of the application. can be 'info', or 'debug', or
+  # anything else to suppress logging.
+  logLevel: verbose
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+
 storage:
   gcp:
     # -- Name of a GCP project that has a bucket for database storage
@@ -50,3 +82,24 @@ storage:
     alertBucket: ""
     # -- Name of a Google Cloud Storage bucket in GCP with schema data
     schemaBucket: ""
+
+ingress:
+  # -- Whether to create an ingress
+  enabled: true
+
+  # Additional annotations to add to the ingress
+  annotations: {}
+
+  # -- Hostname for the ingress
+  # @default -- None, must be set if the ingress is enabled
+  host: ""
+
+  # -- Configures TLS for the ingress if needed. If multiple ingresses share
+  # the same hostname, only one of them needs a TLS configuration.
+  tls: []
+
+  # -- Subpath to host the alert database application under the ingress
+  path: "/alertdb"
+
+  # -- Query string for Gafaelfawr to authorize access
+  gafaelfawrAuthQuery: "scope=exec:admin"


### PR DESCRIPTION
Adds an HTTP server frontend to the alert database buckets.

Adds a ServiceAccount, Ingress, Service, and Deployment for accessing the data inside the alert database's buckets.