### PR TITLE
DM-32644: alert-database: use rewrite-target, not app-root

### DIFF
--- a/charts/alert-database/Chart.yaml
+++ b/charts/alert-database/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: alert-database
-version: 2.0.1
+version: 2.0.2
 description: Archival database of alerts sent through the alert stream.
 maintainers:
   - name: swnelson

--- a/charts/alert-database/README.md
+++ b/charts/alert-database/README.md
@@ -1,6 +1,6 @@
 # alert-database
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Archival database of alerts sent through the alert stream.
 

--- a/charts/alert-database/templates/ingress.yaml
+++ b/charts/alert-database/templates/ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/app-root: {{ .Values.ingress.path | quote }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?{{ required "ingress.gafaelfawrAuthQuery must be set" .Values.ingress.gafaelfawrAuthQuery }}"
     {{- with .Values.ingress.annotations }}
@@ -18,8 +18,7 @@ spec:
     - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path | quote }}
-            pathType: Prefix
+          - path: "{{ .Values.ingress.path }}(/|$)(.*)"
             backend:
               service:
                 name: {{ template "alertDatabase.fullname" . }}


### PR DESCRIPTION
This was causing all requests to be redirected to the alertdb service. What I actually wanted was to rewrite requests.