### PR TITLE
[DM-32991] Fix apiVersion for cadc-tap-postgres Ingresses

### DIFF
--- a/charts/cadc-tap-postgres/Chart.yaml
+++ b/charts/cadc-tap-postgres/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/lsst-sqre/tap-postgres
 name: cadc-tap-postgres
 maintainers:
   - name: cbanek
-version: 0.1.4
+version: 0.1.5

--- a/charts/cadc-tap-postgres/templates/tap-ingress-anonymous.yaml
+++ b/charts/cadc-tap-postgres/templates/tap-ingress-anonymous.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/charts/cadc-tap-postgres/templates/tap-ingress-authenticated.yaml
+++ b/charts/cadc-tap-postgres/templates/tap-ingress-authenticated.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
The syntax was updated for the new apiVersion, but the apiVersion
update itself was missed.