### PR TITLE
[DM-33222] Increase mobu readiness probe timeout

### DIFF
--- a/charts/mobu/Chart.yaml
+++ b/charts/mobu/Chart.yaml
@@ -4,5 +4,5 @@ home: https://github.com/lsst-sqre/mobu
 maintainers:
   - name: cbanek
 name: mobu
-version: 3.1.1
+version: 3.1.2
 appVersion: 4.1.0

--- a/charts/mobu/README.md
+++ b/charts/mobu/README.md
@@ -1,6 +1,6 @@
 # mobu
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
+![Version: 3.1.2](https://img.shields.io/badge/Version-3.1.2-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
 
 Generate system load by pretending to be a random scientist
 

--- a/charts/mobu/templates/statefulset.yaml
+++ b/charts/mobu/templates/statefulset.yaml
@@ -63,6 +63,7 @@ spec:
             httpGet:
               path: "/mobu/flocks"
               port: "http"
+            timeoutSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
We were seeing the pod intermittently be marked as not ready even
though it seemed to be running fine.  The theory is that it was
taking longer than 1s under load.  Increase the readiness probe
timeout to 10s.