### PR TITLE
[DM-33257] Add Confluent schema registry to Sasquatch Helm chart

### DIFF
--- a/charts/sasquatch/Chart.yaml
+++ b/charts/sasquatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sasquatch
-version: 0.1.0
+version: 0.1.1
 description: A Helm chart to deploy Sasquatch components on Kubernetes
 maintainers:
   - name: afausti
@@ -9,4 +9,4 @@ type: application
 appVersion: "0.1.0"
 dependencies:
   - name: "strimzi-kafka"
-    version: "0.1.0"
+    version: "0.1.1"

--- a/charts/sasquatch/Chart.yaml
+++ b/charts/sasquatch/Chart.yaml
@@ -10,3 +10,6 @@ appVersion: "0.1.0"
 dependencies:
   - name: "strimzi-kafka"
     version: "0.1.1"
+  - name: strimzi-registry-operator
+    version: 1.1.0
+    repository: https://lsst-sqre.github.io/charts/

--- a/charts/sasquatch/Chart.yaml
+++ b/charts/sasquatch/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
   - name: "strimzi-kafka"
     version: "0.1.1"
   - name: strimzi-registry-operator
-    version: 1.1.0
+    version: 1.2.0
     repository: https://lsst-sqre.github.io/charts/

--- a/charts/sasquatch/Chart.yaml
+++ b/charts/sasquatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sasquatch
-version: 0.1.1
+version: 0.1.2
 description: A Helm chart to deploy Sasquatch components on Kubernetes
 maintainers:
   - name: afausti

--- a/charts/sasquatch/README.md
+++ b/charts/sasquatch/README.md
@@ -1,6 +1,6 @@
 # sasquatch
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart to deploy Sasquatch components on Kubernetes
 
@@ -9,6 +9,12 @@ A Helm chart to deploy Sasquatch components on Kubernetes
 | Name | Email | Url |
 | ---- | ------ | --- |
 | afausti | afausti@lsst.org |  |
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+|  | strimzi-kafka | 0.1.1 |
 
 ## Values
 

--- a/charts/sasquatch/charts/strimzi-kafka/Chart.yaml
+++ b/charts/sasquatch/charts/strimzi-kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: strimzi-kafka
-version: 0.1.0
+version: 0.1.1
 description: A Helm chart to deploy Strimzi Kafka components for Sasquatch
 maintainers:
   - name: afausti

--- a/charts/sasquatch/charts/strimzi-kafka/README.md
+++ b/charts/sasquatch/charts/strimzi-kafka/README.md
@@ -1,6 +1,6 @@
 # strimzi-kafka
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart to deploy Strimzi Kafka components for Sasquatch
 
@@ -24,6 +24,7 @@ A Helm chart to deploy Strimzi Kafka components for Sasquatch
 | kafka.storage.size | string | `"100Gi"` | Size of the backing storage disk for each of the Kafka brokers. |
 | kafka.storage.storageClassName | string | `""` | Name of a StorageClass to use when requesting persistent volumes. |
 | kafka.version | string | `"3.0.0"` | Version of Kafka to deploy. |
+| registry.schemaTopic | string | `"registry-schemas"` | Name of the topic used by the Schema Registry |
 | superusers | list | `["kafka-admin"]` | A list of usernames for users who should have global admin permissions. These users will be created, along with their credentials. |
 | zookeeper.replicas | int | `3` | Number of Zookeeper replicas to run. |
 | zookeeper.storage.size | string | `"100Gi"` | Size of the backing storage disk for each of the Zookeeper instances. |

--- a/charts/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/charts/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -48,3 +48,6 @@ spec:
       size: {{ .Values.zookeeper.storage.size }}
       class: {{ .Values.zookeeper.storage.storageClassName }}
       deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/charts/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/charts/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -8,14 +8,27 @@ spec:
     version: {{ .Values.kafka.version | quote }}
     replicas: {{ .Values.kafka.replicas }}
     listeners:
-      - name: plain
+      - name: internal
         port: 9092
         type: internal
-        tls: false
+        tls: true
+        authentication:
+          type: tls
       - name: tls # Used by the schema registry; it has a fixed name it expects
         port: 9093
         type: internal
         tls: true
+        authentication:
+          type: tls
+    authorization:
+      type: simple
+{{- if .Values.superusers }}
+      superUsers:
+{{- range .Values.superusers }}
+        - {{ . }}
+{{- end }}
+{{- end }}
+
     config:
       offsets.topic.replication.factor:  {{ .Values.kafka.replicas }}
       transaction.state.log.replication.factor:  {{ .Values.kafka.replicas }}

--- a/charts/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/charts/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -12,7 +12,7 @@ spec:
         port: 9092
         type: internal
         tls: false
-      - name: tls
+      - name: tls # Used by the schema registry; it has a fixed name it expects
         port: 9093
         type: internal
         tls: true

--- a/charts/sasquatch/charts/strimzi-kafka/templates/schema-registry-topic.yaml
+++ b/charts/sasquatch/charts/strimzi-kafka/templates/schema-registry-topic.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{ .Values.registry.schemaTopic }}
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    cleanup.policy: compact

--- a/charts/sasquatch/charts/strimzi-kafka/templates/schema-registry-user.yaml
+++ b/charts/sasquatch/charts/strimzi-kafka/templates/schema-registry-user.yaml
@@ -1,0 +1,49 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: {{ .Values.cluster.name }}-schema-registry
+  labels:
+    strimzi.io/cluster: {{ .Values.cluster.name }}
+spec:
+  authentication:
+    type: tls
+  authorization:
+    # Official docs on authorizations required for the Schema Registry:
+    # https://docs.confluent.io/current/schema-registry/security/index.html#authorizing-access-to-the-schemas-topic
+    type: simple
+    acls:
+      # Allow Read, Write and DescribeConfigs operations on the
+      # schemas topic
+      - resource:
+          type: topic
+          name: {{ .Values.registry.schemaTopic }}
+          patternType: literal
+        operation: Read
+        type: allow
+      - resource:
+          type: topic
+          name: {{ .Values.registry.schemaTopic }}
+          patternType: literal
+        operation: Write
+        type: allow
+      - resource:
+          type: topic
+          name: {{ .Values.registry.schemaTopic }}
+          patternType: literal
+        operation: DescribeConfigs
+        type: allow
+      # Allow all operations on the schema-registry* group
+      - resource:
+          type: group
+          name: schema-registry
+          patternType: prefix
+        operation: All
+        type: allow
+      # Allow Describe on the __consumer_offsets topic
+      # (The official docs also mention DescribeConfigs?)
+      - resource:
+          type: topic
+          name: "__consumer_offsets"
+          patternType: literal
+        operation: Describe
+        type: allow

--- a/charts/sasquatch/charts/strimzi-kafka/templates/schema-registry.yaml
+++ b/charts/sasquatch/charts/strimzi-kafka/templates/schema-registry.yaml
@@ -1,0 +1,6 @@
+apiVersion: roundtable.lsst.codes/v1beta1
+kind: StrimziSchemaRegistry
+metadata:
+  name: {{ .Values.cluster.name }}-schema-registry
+spec:
+  listener: tls

--- a/charts/sasquatch/charts/strimzi-kafka/values.yaml
+++ b/charts/sasquatch/charts/strimzi-kafka/values.yaml
@@ -36,6 +36,10 @@ connect:
   # -- Number of Kafka Connect replicas to run.
   replicas: 3
 
+registry:
+  # -- Name of the topic used by the Schema Registry
+  schemaTopic: registry-schemas
+
 # -- A list of usernames for users who should have global admin permissions.
 # These users will be created, along with their credentials.
 superusers:

--- a/charts/sasquatch/values.yaml
+++ b/charts/sasquatch/values.yaml
@@ -1,3 +1,7 @@
 # Override default values for the Sasquatch subcharts.
 
 strimzi-kafka: {}
+
+strimzi-registry-operator:
+  clusterName: sasquatch
+  watchNamespace: sasquatch

--- a/charts/sasquatch/values.yaml
+++ b/charts/sasquatch/values.yaml
@@ -5,3 +5,4 @@ strimzi-kafka: {}
 strimzi-registry-operator:
   clusterName: sasquatch
   watchNamespace: sasquatch
+  operatorNamespace: sasquatch


### PR DESCRIPTION
- Use the schema-registry-operator to add Confluent schema registry to Sasquatch Helm chart
- Deploy the strimzi entity operator to create the schema registry topic and user
- Enable authentication and authorization
- Ingress configuration for the schema registry will be added in another PR