### PR TITLE
[DM-33244] Update moneypenny chart

### DIFF
--- a/charts/moneypenny/Chart.yaml
+++ b/charts/moneypenny/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.3.3"
+appVersion: "1.0.0"
 description: User provisioning actions for the Science Platform
 name: moneypenny
 maintainers:
   - name: athornton
   - name: rra
-version: 0.3.3
+version: 1.0.0

--- a/charts/moneypenny/README.md
+++ b/charts/moneypenny/README.md
@@ -1,6 +1,6 @@
 # moneypenny
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![AppVersion: 0.3.3](https://img.shields.io/badge/AppVersion-0.3.3-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 User provisioning actions for the Science Platform
 

--- a/charts/moneypenny/templates/ingress.yaml
+++ b/charts/moneypenny/templates/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?{{ required "ingress.gafaelfawrAuthQuery must be set" .Values.ingress.gafaelfawrAuthQuery }}"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "310"
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/moneypenny/templates/role.yaml
+++ b/charts/moneypenny/templates/role.yaml
@@ -6,8 +6,16 @@ metadata:
     {{- include "moneypenny.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: [ "pods" ]
-    verbs: ["get", "create",  "delete"]  
+    resources:
+      - "pods"
+    verbs:
+      - "create"
+      - "delete"
+      - "get"
+      - "list"
+      - "watch"
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create",  "delete"]
+    verbs:
+      - "create"
+      - "delete"

--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nublado2
-version: 0.5.8
-appVersion: "1.4.3"
+version: 0.6.0
+appVersion: "1.5.0"
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2
 maintainers:

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -6,7 +6,7 @@ jupyterhub:
   hub:
     image:
       name: lsstsqre/nublado2
-      tag: "1.4.3"
+      tag: "1.5.0"
     config:
       Authenticator:
         enable_auth_state: true


### PR DESCRIPTION
Update for the 1.0.0 release.  Add permissions to list and watch
pods so that we can use a watch to wait for the provisioning pod
to finish.  Increase the NGINX proxy timeout to 5m plus ten seconds,
which is long enough to wait for the default timeout for a pod to
run.