### PR TITLE
DM-33025: Initial redis integration for noteburst (noteburst 0.2.0-alpha.1)

### DIFF
--- a/charts/noteburst/.gitignore
+++ b/charts/noteburst/.gitignore
@@ -1,0 +1,2 @@
+charts/*.tgz
+Chart.lock

--- a/charts/noteburst/Chart.yaml
+++ b/charts/noteburst/Chart.yaml
@@ -12,10 +12,16 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.0-alpha.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "tickets-DM-33025"
+
+# Additional charts that this chart uses
+dependencies:
+  - name: redis
+    version: 16.0.1
+    repository: https://charts.bitnami.com/bitnami

--- a/charts/noteburst/templates/configmap.yaml
+++ b/charts/noteburst/templates/configmap.yaml
@@ -7,6 +7,6 @@ metadata:
 data:
   SAFIR_NAME: {{ .Values.config.name | quote }}
   SAFIR_PROFILE: {{ .Values.config.profile | quote }}
-  SAFIR_LOG_LEVEL: {{ .Values.config.log_level | quote }}
-  SAFIR_LOGGER: {{ .Values.config.logger_name | quote }}
-  NOTEBURST_ENVIRONMENT_URL: {{ .Values.config.environment_url | quote }}
+  SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  SAFIR_LOGGER: {{ .Values.config.loggerName | quote }}
+  NOTEBURST_ENVIRONMENT_URL: {{ .Values.config.environmentUrl | quote }}

--- a/charts/noteburst/templates/configmap.yaml
+++ b/charts/noteburst/templates/configmap.yaml
@@ -10,3 +10,4 @@ data:
   SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   SAFIR_LOGGER: {{ .Values.config.loggerName | quote }}
   NOTEBURST_ENVIRONMENT_URL: {{ .Values.config.environmentUrl | quote }}
+  NOTEBURST_REDIS_URL: "redis://redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/0"

--- a/charts/noteburst/values.yaml
+++ b/charts/noteburst/values.yaml
@@ -100,3 +100,7 @@ config:
   # and TAP
   # @default -- None, must be set
   environmentUrl: ""
+
+redis:
+  auth:
+    enabled: false

--- a/charts/noteburst/values.yaml
+++ b/charts/noteburst/values.yaml
@@ -93,10 +93,10 @@ config:
   # -- Run profile: "production" or "development"
   profile: "production"
   # -- Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
-  log_level: "INFO"
+  logLevel: "INFO"
   # -- Logger name
-  logger_name: "noteburst"
+  loggerName: "noteburst"
   # -- Base URL used to find other services in the environment such as Nublado
   # and TAP
   # @default -- None, must be set
-  environment_url: ""
+  environmentUrl: ""


### PR DESCRIPTION
This 0.2.0-alpha.1 release includes a redis sub-chart to begin integrating the deployment or noteburst's redis queue.