### PR TITLE
DM-33025: Implement noteburst worker pool (Noteburst 0.2.0-alpha.3)

### DIFF
--- a/charts/noteburst/Chart.yaml
+++ b/charts/noteburst/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0-alpha.2
+version: 0.2.0-alpha.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/noteburst/README.md
+++ b/charts/noteburst/README.md
@@ -1,6 +1,6 @@
 # noteburst
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.0-alpha.3](https://img.shields.io/badge/Version-0.2.0--alpha.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: tickets-DM-33025](https://img.shields.io/badge/AppVersion-tickets--DM--33025-informational?style=flat-square)
 
 Noteburst is a notebook execution service for the Rubin Science Platform.
 
@@ -16,6 +16,12 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 
 * <https://github.com/lsst-sqre/noteburst>
 
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | redis | 16.0.1 |
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -25,11 +31,13 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| config.environment_url | string | None, must be set | Base URL used to find other services in the environment such as Nublado and TAP |
-| config.log_level | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
-| config.logger_name | string | `"noteburst"` | Logger name |
+| config.environmentUrl | string | None, must be set | Base URL used to find other services in the environment such as Nublado and TAP |
+| config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
+| config.loggerName | string | `"noteburst"` | Logger name |
 | config.name | string | `"noteburst"` | Name of the service, and path where the external API is exposed. |
 | config.profile | string | `"production"` | Run profile: "production" or "development" |
+| config.worker.identities | list | `[]` | Science Platform user identies that workers can acquire. Each item is an object with username and uuid keys |
+| config.worker.workerCount | int | `1` | Number of workers to run |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lsstsqre/noteburst"` |  |
@@ -49,6 +57,7 @@ Noteburst is a notebook execution service for the Rubin Science Platform.
 | podSecurityContext.runAsGroup | int | `1000` |  |
 | podSecurityContext.runAsNonRoot | bool | `true` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |
+| redis.auth.enabled | bool | `false` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext.capabilities.drop[0] | string | `"all"` |  |

--- a/charts/noteburst/templates/configmap.yaml
+++ b/charts/noteburst/templates/configmap.yaml
@@ -10,4 +10,4 @@ data:
   SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   SAFIR_LOGGER: {{ .Values.config.loggerName | quote }}
   NOTEBURST_ENVIRONMENT_URL: {{ .Values.config.environmentUrl | quote }}
-  NOTEBURST_REDIS_URL: "redis://{{ printf "%s-master" (include "common.names.fullname" .) }}.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/0"
+  NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/0"

--- a/charts/noteburst/templates/worker-configmap.yaml
+++ b/charts/noteburst/templates/worker-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "noteburst.fullname" . }}-worker
+  labels:
+    {{- include "noteburst.labels" . | nindent 4 }}
+data:
+  SAFIR_NAME: {{ .Values.config.name | quote }}
+  SAFIR_PROFILE: {{ .Values.config.profile | quote }}
+  SAFIR_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  SAFIR_LOGGER: {{ .Values.config.loggerName | quote }}
+  NOTEBURST_ENVIRONMENT_URL: {{ .Values.config.environmentUrl | quote }}
+  NOTEBURST_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/0"
+  NOTEBURST_WORKER_LOCK_REDIS_URL: "redis://{{ include "noteburst.fullname" . }}-redis-master.{{ .Release.Namespace }}:{{ .Values.redis.master.service.ports.redis }}/1"

--- a/charts/noteburst/templates/worker-deployment.yaml
+++ b/charts/noteburst/templates/worker-deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "noteburst.fullname" . }}-worker
+  labels:
+    {{- include "noteburst.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.config.worker.workerCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "noteburst.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/worker-configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "noteburst.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "noteburst.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["arq"]
+          args: ["noteburst.worker.main.WorkerSettings"]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "noteburst.fullname" . }}-worker
+          env:
+            - name: "NOTEBURST_GAFAELFAWR_TOKEN"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "noteburst.fullname" . }}-gafaelfawr-token
+                  key: "token"
+            - name: "NOTEBURST_WORKER_IDENTITIES_PATH"
+              value: "/etc/noteburst/identities.yaml"
+          volumeMounts:
+            - name: "identities"
+              mountPath: "/etc/noteburst"
+              readOnly: true
+      volumes:
+        - name: "identities"
+          configMap:
+            name: {{ include "noteburst.fullname" . }}-worker-identities
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/noteburst/templates/worker-identities-configmap.yaml
+++ b/charts/noteburst/templates/worker-identities-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "noteburst.fullname" . }}-worker-identities
+  labels:
+    {{- include "noteburst.labels" . | nindent 4 }}
+data:
+  identities.yaml: |
+    {{- toYaml .Values.config.worker.identities | nindent 4 }}

--- a/charts/noteburst/values.yaml
+++ b/charts/noteburst/values.yaml
@@ -101,6 +101,13 @@ config:
   # @default -- None, must be set
   environmentUrl: ""
 
+  worker:
+    # -- Science Platform user identies that workers can acquire. Each item
+    # is an object with username and uuid keys
+    identities: []
+    # -- Number of workers to run
+    workerCount: 1
+
 redis:
   auth:
     enabled: false


### PR DESCRIPTION
Workers are deployed as a Deployment. The worker.identities field in values.yaml defines Science Platform identities that each worker instance can acquire at start-up.