### PR TITLE
[DM-26506] Clean up gafaelfawrAuthQuery configuration

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cachemachine
-version: 1.2.0
+version: 1.2.1
 description: Service to prepull Docker images for the Science Platform
 maintainers:
   - name: cbanek

--- a/charts/cachemachine/templates/ingress.yaml
+++ b/charts/cachemachine/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.gafaelfawrAuthQuery }}"
+    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
     {{- end }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/datalinker/Chart.yaml
+++ b/charts/datalinker/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.0.0
 description: A Helm chart for Kubernetes
 name: datalinker
 type: application
-version: 0.1.4
+version: 0.1.5
 maintainers:
   - name: cbanek

--- a/charts/datalinker/templates/ingress.yaml
+++ b/charts/datalinker/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.gafaelfawrAuthQuery }}"
+    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
     {{- end }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/datalinker/values.yaml
+++ b/charts/datalinker/values.yaml
@@ -41,8 +41,7 @@ ingress:
   # -- Hostname of the deployment to run behind
   host: ""
 
-  # -- Gafaelfawr Auth Query string (default, unauthenticated)
-  # gafaelfawrAuthQuery: "scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
+  # -- Gafaelfawr auth query string (default, unauthenticated)
   gafaelfawrAuthQuery: ""
 
   # -- Additional annotations for the ingress rule

--- a/charts/mobu/Chart.yaml
+++ b/charts/mobu/Chart.yaml
@@ -4,5 +4,5 @@ home: https://github.com/lsst-sqre/mobu
 maintainers:
   - name: cbanek
 name: mobu
-version: 3.2.0
+version: 3.2.1
 appVersion: 4.1.0

--- a/charts/mobu/templates/ingress.yaml
+++ b/charts/mobu/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.gafaelfawrAuthQuery }}"
+    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
     {{- end }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/sherlock/Chart.yaml
+++ b/charts/sherlock/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 0.1.1
 description: A Helm chart for Kubernetes
 name: sherlock
 type: application
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: cbanek

--- a/charts/sherlock/templates/ingress.yaml
+++ b/charts/sherlock/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.gafaelfawrAuthQuery }}"
+    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
     {{- end }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/sherlock/values.yaml
+++ b/charts/sherlock/values.yaml
@@ -41,8 +41,7 @@ ingress:
   # -- Hostname of the deployment to run behind
   host: ""
 
-  # -- Gafaelfawr Auth Query string (default, unauthenticated)
-  # gafaelfawrAuthQuery: "scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
+  # -- Gafaelfawr auth query string (default, unauthenticated)
   gafaelfawrAuthQuery: ""
 
   # -- Additional annotations for the ingress rule

--- a/charts/times-square/Chart.yaml
+++ b/charts/times-square/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The chart version.
-version: 0.1.2
+version: 0.1.3
 
 # The app's version corresponding to the image tag.
 appVersion: "0.1.0"

--- a/charts/times-square/templates/ingress.yaml
+++ b/charts/times-square/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.gafaelfawrAuthQuery }}"
+    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
     {{- end }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/times-square/values.yaml
+++ b/charts/times-square/values.yaml
@@ -41,8 +41,7 @@ ingress:
   # -- Hostname of the deployment to run behind
   host: ""
 
-  # -- Gafaelfawr Auth Query string (default, unauthenticated)
-  # gafaelfawrAuthQuery: "scope=exec:portal&delegate_to=portal&delegate_scope=read:tap"
+  # -- Gafaelfawr auth query string (default, unauthenticated)
   gafaelfawrAuthQuery: ""
 
   # -- Additional annotations for the ingress rule

--- a/rsp-starter/templates/ingress.yaml
+++ b/rsp-starter/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token"
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
-    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.gafaelfawrAuthQuery }}"
+    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
     {{- end }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
The rsp-starter and thus some of the charts incorrectly referenced
.Values.gafaelfawrAuthQuery instead of
.Values.ingress.gafaelfawrAuthQuery.