### PR TITLE
[DM-26506] Fix NetworkPolicy ports

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cachemachine
-version: 1.2.1
+version: 1.2.2
 description: Service to prepull Docker images for the Science Platform
 maintainers:
   - name: cbanek

--- a/charts/cachemachine/templates/networkpolicy.yaml
+++ b/charts/cachemachine/templates/networkpolicy.yaml
@@ -19,5 +19,5 @@ spec:
               gafaelfawr.lsst.io/ingress: "true"
       ports:
         - protocol: "TCP"
-          port: {{ .Values.service.port }}
+          port: 8080
 {{- end }}

--- a/charts/datalinker/Chart.yaml
+++ b/charts/datalinker/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 1.0.0
 description: A Helm chart for Kubernetes
 name: datalinker
 type: application
-version: 0.1.5
+version: 0.1.6
 maintainers:
   - name: cbanek

--- a/charts/datalinker/templates/networkpolicy.yaml
+++ b/charts/datalinker/templates/networkpolicy.yaml
@@ -19,5 +19,5 @@ spec:
               gafaelfawr.lsst.io/ingress: "true"
       ports:
         - protocol: "TCP"
-          port: {{ .Values.service.port }}
+          port: 8080
 {{- end }}

--- a/charts/mobu/Chart.yaml
+++ b/charts/mobu/Chart.yaml
@@ -4,5 +4,5 @@ home: https://github.com/lsst-sqre/mobu
 maintainers:
   - name: cbanek
 name: mobu
-version: 3.2.1
+version: 3.2.2
 appVersion: 4.1.0

--- a/charts/mobu/templates/networkpolicy.yaml
+++ b/charts/mobu/templates/networkpolicy.yaml
@@ -19,5 +19,5 @@ spec:
               gafaelfawr.lsst.io/ingress: "true"
       ports:
         - protocol: "TCP"
-          port: {{ .Values.service.port }}
+          port: 8080
 {{- end }}

--- a/charts/moneypenny/Chart.yaml
+++ b/charts/moneypenny/Chart.yaml
@@ -5,4 +5,4 @@ name: moneypenny
 maintainers:
   - name: athornton
   - name: rra
-version: 1.0.1
+version: 1.0.2

--- a/charts/moneypenny/templates/networkpolicy.yaml
+++ b/charts/moneypenny/templates/networkpolicy.yaml
@@ -20,4 +20,4 @@ spec:
               gafaelfawr.lsst.io/ingress: "true"
       ports:
         - protocol: "TCP"
-          port: {{ .Values.service.port }}
+          port: 8080

--- a/charts/sherlock/Chart.yaml
+++ b/charts/sherlock/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 0.1.1
 description: A Helm chart for Kubernetes
 name: sherlock
 type: application
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - name: cbanek

--- a/charts/sherlock/templates/networkpolicy.yaml
+++ b/charts/sherlock/templates/networkpolicy.yaml
@@ -19,5 +19,5 @@ spec:
               gafaelfawr.lsst.io/ingress: "true"
       ports:
         - protocol: "TCP"
-          port: {{ .Values.service.port }}
+          port: 8080
 {{- end }}

--- a/charts/times-square/Chart.yaml
+++ b/charts/times-square/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The chart version.
-version: 0.1.3
+version: 0.1.4
 
 # The app's version corresponding to the image tag.
 appVersion: "0.1.0"

--- a/charts/times-square/templates/networkpolicy.yaml
+++ b/charts/times-square/templates/networkpolicy.yaml
@@ -19,5 +19,5 @@ spec:
               gafaelfawr.lsst.io/ingress: "true"
       ports:
         - protocol: "TCP"
-          port: {{ .Values.service.port }}
+          port: 8080
 {{- end }}

--- a/rsp-starter/templates/networkpolicy.yaml
+++ b/rsp-starter/templates/networkpolicy.yaml
@@ -19,5 +19,5 @@ spec:
               gafaelfawr.lsst.io/ingress: "true"
       ports:
         - protocol: "TCP"
-          port: {{ .Values.service.port }}
+          port: 8080
 {{- end }}


### PR DESCRIPTION
A NetworkPolicy has to reference the pod port, not the service
port, and rsp-starter had this incorrect.