### PR TITLE
[DM-33241] Fix name of mock-qserv service

### DIFF
--- a/charts/cadc-tap/Chart.yaml
+++ b/charts/cadc-tap/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/lsst-sqre/lsst-tap-service
 maintainers:
   - name: cbanek
 name: cadc-tap
-version: 1.0.1
+version: 1.0.2

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -1,6 +1,6 @@
 # cadc-tap
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
 
 A Helm chart for the CADC TAP service
 

--- a/charts/cadc-tap/templates/mock-qserv-service.yaml
+++ b/charts/cadc-tap/templates/mock-qserv-service.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: "qserv-master01"
+  name: "mock-qserv"
   labels:
     {{- include "cadc-tap.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
This has to be called mock-qserv to match the default setting in
the values.yaml file when mock Qserv is enabled.