### PR TITLE
[DM-33241] Fix security settings for cadc-tap databases

### DIFF
--- a/charts/cadc-tap/Chart.yaml
+++ b/charts/cadc-tap/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/lsst-sqre/lsst-tap-service
 maintainers:
   - name: cbanek
 name: cadc-tap
-version: 1.0.2
+version: 1.0.3

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -1,6 +1,6 @@
 # cadc-tap
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
 
 A Helm chart for the CADC TAP service
 

--- a/charts/cadc-tap/templates/mock-qserv-deployment.yaml
+++ b/charts/cadc-tap/templates/mock-qserv-deployment.yaml
@@ -26,10 +26,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: false
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
       containers:
         - name: "mock-qserv"
           securityContext:
@@ -37,7 +33,6 @@ spec:
             capabilities:
               drop:
                 - "all"
-            readOnlyRootFilesystem: true
           image: "{{ .Values.qserv.mock.image.repository }}:{{ .Values.qserv.mock.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.qserv.mock.image.pullPolicy | quote }}
           ports:

--- a/charts/cadc-tap/templates/uws-db-deployment.yaml
+++ b/charts/cadc-tap/templates/uws-db-deployment.yaml
@@ -26,10 +26,10 @@ spec:
       {{- end }}
       automountServiceAccountToken: false
       securityContext:
-        fsGroup: 1000
+        fsGroup: 999
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 999
+        runAsGroup: 999
       containers:
         - name: "postgresql"
           securityContext:


### PR DESCRIPTION
Run mock-qserv as root with a writable file system for now, since
the startup of its Docker image apparently requires rewriting files
in /etc (why?).  Fixing this looks like a larger issue.

Fix the user the uws-db container runs as to hopefully match the
UID and GID of the postgres user and thus solve initdb issues.