### PR TITLE
[DM-33241] Drop more security settings for cadc-tap

### DIFF
--- a/charts/cadc-tap/Chart.yaml
+++ b/charts/cadc-tap/Chart.yaml
@@ -5,4 +5,4 @@ home: https://github.com/lsst-sqre/lsst-tap-service
 maintainers:
   - name: cbanek
 name: cadc-tap
-version: 1.0.3
+version: 1.0.4

--- a/charts/cadc-tap/README.md
+++ b/charts/cadc-tap/README.md
@@ -1,6 +1,6 @@
 # cadc-tap
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
 
 A Helm chart for the CADC TAP service
 

--- a/charts/cadc-tap/templates/mock-qserv-deployment.yaml
+++ b/charts/cadc-tap/templates/mock-qserv-deployment.yaml
@@ -28,11 +28,6 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: "mock-qserv"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
           image: "{{ .Values.qserv.mock.image.repository }}:{{ .Values.qserv.mock.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.qserv.mock.image.pullPolicy | quote }}
           ports:

--- a/charts/cadc-tap/templates/tap-deployment.yaml
+++ b/charts/cadc-tap/templates/tap-deployment.yaml
@@ -25,18 +25,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: false
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
       containers:
         - name: "tap-server"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "all"
-            readOnlyRootFilesystem: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           env:

--- a/charts/cadc-tap/templates/uws-db-deployment.yaml
+++ b/charts/cadc-tap/templates/uws-db-deployment.yaml
@@ -25,11 +25,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: false
-      securityContext:
-        fsGroup: 999
-        runAsNonRoot: true
-        runAsUser: 999
-        runAsGroup: 999
       containers:
         - name: "postgresql"
           securityContext:


### PR DESCRIPTION
The containers apparently cannot currently run with most reasonable
security settings and that will require additional work.