### PR TITLE
[DM-33479] Make Renovate bot bump chart version automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "extends": [
     "config:base", "schedule:weekly"
   ],
-  "versioning": "docker"
+  "versioning": "docker",
+  "bumpVersion": "patch"
 }


### PR DESCRIPTION
Looks like [bumpVersion](https://docs.renovatebot.com/configuration-options/#bumpversion) is the configuration we need to automatically bump the chart version. 