### PR TITLE
[DM-33445] Disable TLS encryption in one of the internal listeners

### DIFF
--- a/charts/sasquatch/Chart.yaml
+++ b/charts/sasquatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sasquatch
-version: 0.1.6
+version: 0.1.7
 description: A Helm chart to deploy Sasquatch components on Kubernetes
 maintainers:
   - name: afausti

--- a/charts/sasquatch/README.md
+++ b/charts/sasquatch/README.md
@@ -1,6 +1,6 @@
 # sasquatch
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart to deploy Sasquatch components on Kubernetes
 
@@ -15,7 +15,7 @@ A Helm chart to deploy Sasquatch components on Kubernetes
 | Repository | Name | Version |
 |------------|------|---------|
 |  | strimzi-kafka | 0.1.1 |
-| https://helm.influxdata.com/ | influxdb | 4.10.3 |
+| https://helm.influxdata.com/ | influxdb | 4.10.4 |
 | https://lsst-sqre.github.io/charts/ | strimzi-registry-operator | 1.2.0 |
 
 ## Values

--- a/charts/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
+++ b/charts/sasquatch/charts/strimzi-kafka/templates/kafka.yaml
@@ -8,12 +8,10 @@ spec:
     version: {{ .Values.kafka.version | quote }}
     replicas: {{ .Values.kafka.replicas }}
     listeners:
-      - name: internal
+      - name: plain
         port: 9092
         type: internal
-        tls: true
-        authentication:
-          type: tls
+        tls: false
       - name: tls # Used by the schema registry; it has a fixed name it expects
         port: 9093
         type: internal


### PR DESCRIPTION
This plain listener is going to be used to connect to Kafka from within the cluster without for clients like kafka-connect-manager and SAL Kafka producers. 