### PR TITLE
fix: underscore for ldap base_dn

### DIFF
--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -106,7 +106,7 @@ data:
     {{- if .Values.config.ldap.url }}
     ldap:
       url: {{ .Values.config.ldap.url | quote }}
-      baseDn: {{ required "config.ldap.baseDn must be set" .Values.config.ldap.baseDn | quote }}
+      base_dn: {{ required "config.ldap.baseDn must be set" .Values.config.ldap.baseDn | quote }}
       groupObjectClass: {{ .Values.config.ldap.groupObjectClass | quote }}
       groupMember: {{ .Values.config.ldap.groupMember | quote }}
     {{- end }}


### PR DESCRIPTION
gafaelfawr expects `ldap.base_dn` rather than `ldap.baseDn`. this patch changes the key to use underscore rather than camelcase.

```
Traceback (most recent call last):
  File "/opt/venv/bin/gafaelfawr", line 8, in <module>
    sys.exit(main())
  File "/opt/venv/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/opt/venv/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/venv/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/venv/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/gafaelfawr/cli.py", line 40, in wrapper
    return asyncio.run(f(*args, **kwargs))
  File "/usr/local/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 641, in run_until_complete
    return future.result()
  File "/opt/venv/lib/python3.10/site-packages/gafaelfawr/cli.py", line 109, in init
    config = await config_dependency()
  File "/opt/venv/lib/python3.10/site-packages/gafaelfawr/dependencies/config.py", line 34, in __call__
    self._load_config()
  File "/opt/venv/lib/python3.10/site-packages/gafaelfawr/dependencies/config.py", line 51, in _load_config
    self._config = Config.from_file(self._settings_path)
  File "/opt/venv/lib/python3.10/site-packages/gafaelfawr/config.py", line 647, in from_file
    settings = Settings.parse_obj(raw_settings)
  File "pydantic/main.py", line 511, in pydantic.main.BaseModel.parse_obj
  File "pydantic/env_settings.py", line 38, in pydantic.env_settings.BaseSettings.__init__
  File "pydantic/main.py", line 331, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Settings
ldap -> base_dn
  field required (type=value_error.missing)
```