### PR TITLE
[DM-33513] Pass the Google service account to vo-cutouts

### DIFF
--- a/charts/vo-cutouts/Chart.yaml
+++ b/charts/vo-cutouts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vo-cutouts
-version: 0.2.1
+version: 0.2.2
 description: Image cutout service complying with IVOA SODA
 home: https://github.com/lsst-sqre/vo-cutouts
 maintainers:

--- a/charts/vo-cutouts/README.md
+++ b/charts/vo-cutouts/README.md
@@ -1,6 +1,6 @@
 # vo-cutouts
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 Image cutout service complying with IVOA SODA
 
@@ -17,12 +17,12 @@ Image cutout service complying with IVOA SODA
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the vo-cutouts frontend pod |
-| cloudsql.enabled | bool | `false` | Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases on Google Cloud |
+| cloudsql.enabled | bool | `true` | Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases on Google Cloud |
 | cloudsql.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Cloud SQL Auth Proxy images |
 | cloudsql.image.repository | string | `"gcr.io/cloudsql-docker/gce-proxy"` | Cloud SQL Auth Proxy image to use |
 | cloudsql.image.tag | string | `"1.28.1"` | Cloud SQL Auth Proxy tag to use |
 | cloudsql.instanceConnectionName | string | `""` | Instance connection name for a CloudSQL PostgreSQL instance |
-| cloudsql.serviceAccount | string | `""` | The Google service account that has an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role |
+| cloudsql.serviceAccount | string | None, must be set | The Google service account that has an IAM binding to the `vo-cutouts` Kubernetes service accounts and has the `cloudsql.client` role, access to the GCS bucket, and ability to sign URLs as itself |
 | config.butlerRepository | string | None, must be set | Configuration for the Butler repository to use |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.gcsBucketUrl | string | None, must be set | URL for the GCS bucket into which to store cutouts (must start with `s3`) |

--- a/charts/vo-cutouts/templates/configmap.yaml
+++ b/charts/vo-cutouts/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   CUTOUT_BUTLER_REPOSITORY: {{ required "config.butlerRepository must be set" .Values.config.butlerRepository | quote }}
   CUTOUT_DATABASE_URL: {{ required "config.databaseUrl must be set" .Values.config.databaseUrl | quote }}
+  CUTOUT_SERVICE_ACCOUNT: {{ required "cloudsql.serviceAccount must be set" .Values.cloudsql.serviceAccount | quote }}
   CUTOUT_STORAGE_URL: {{ required "config.gcsBucketUrl must be set" .Values.config.gcsBucketUrl | quote }}
   CUTOUT_TIMEOUT: {{ .Values.config.timeout | quote }}
   CUTOUT_LIFETIME: {{ .Values.config.lifetime | quote }}

--- a/charts/vo-cutouts/values.yaml
+++ b/charts/vo-cutouts/values.yaml
@@ -103,7 +103,7 @@ config:
 cloudsql:
   # -- Enable the Cloud SQL Auth Proxy sidecar, used with CloudSQL databases
   # on Google Cloud
-  enabled: false
+  enabled: true
 
   image:
     # -- Cloud SQL Auth Proxy image to use
@@ -119,7 +119,9 @@ cloudsql:
   instanceConnectionName: ""
 
   # -- The Google service account that has an IAM binding to the `vo-cutouts`
-  # Kubernetes service accounts and has the `cloudsql.client` role
+  # Kubernetes service accounts and has the `cloudsql.client` role, access
+  # to the GCS bucket, and ability to sign URLs as itself
+  # @default -- None, must be set
   serviceAccount: ""
 
 cutoutWorker:


### PR DESCRIPTION
The same service account used for CloudSQL will also be used to
access GCS, and must be passed down to the application for GCS URL
signing.