### PR TITLE
Add nginx annotation to exposurelog ingress

### DIFF
--- a/charts/exposurelog/Chart.yaml
+++ b/charts/exposurelog/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.32
+version: 0.1.33
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/exposurelog/templates/ingress.yaml
+++ b/charts/exposurelog/templates/ingress.yaml
@@ -7,10 +7,11 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "exposurelog.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    kubernetes.io/ingress.class: "nginx"
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
The latest ingress-nginx controller requires an explicit annotation
for ingresses that it should pick up.