### PR TITLE
narrativelog: improve ingress

### DIFF
--- a/charts/narrativelog/Chart.yaml
+++ b/charts/narrativelog/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/narrativelog/templates/ingress.yaml
+++ b/charts/narrativelog/templates/ingress.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "narrativelog.fullname" . -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ template "narrativelog.fullname" . }}
   labels:
     {{- include "narrativelog.labels" . | nindent 4 }}
   annotations:
@@ -25,11 +24,11 @@ spec:
     - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: {{ default "/narrativelog" .Values.ingress.path }}
             pathType: {{ default "Prefix" .Values.ingress.pathType }}
             backend:
               service:
-                name: {{ $fullName }}
+                name: {{ include "narrativelog.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
 {{- end }}


### PR DESCRIPTION
Provide a default path while still allowing it to be overridden.
Ditch the unnecessary fullName variable (copying the way moneypenny does it).
Bump the chart version a lot because it seems we are likely close now.