### PR TITLE
[DM-33604] Cleanup and improvements for vo-cutouts chart

### DIFF
--- a/charts/vo-cutouts/Chart.yaml
+++ b/charts/vo-cutouts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vo-cutouts
-version: 0.2.2
+version: 0.2.3
 description: Image cutout service complying with IVOA SODA
 home: https://github.com/lsst-sqre/vo-cutouts
 maintainers:

--- a/charts/vo-cutouts/Chart.yaml
+++ b/charts/vo-cutouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vo-cutouts
-version: 0.2.3
+version: 0.3.0
 description: Image cutout service complying with IVOA SODA
 home: https://github.com/lsst-sqre/vo-cutouts
 maintainers:
   - name: rra
-appVersion: 0.2.0
+appVersion: 0.3.0

--- a/charts/vo-cutouts/README.md
+++ b/charts/vo-cutouts/README.md
@@ -1,6 +1,6 @@
 # vo-cutouts
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 Image cutout service complying with IVOA SODA
 
@@ -36,7 +36,7 @@ Image cutout service complying with IVOA SODA
 | cutoutWorker.image.tag | string | `"7-stack-lsst_distrib-w_2022_06"` | Stack image tag to use |
 | cutoutWorker.nodeSelector | object | `{}` | Node selection rules for the cutout worker pod |
 | cutoutWorker.podAnnotations | object | `{}` | Annotations for the cutout worker pod |
-| cutoutWorker.replicaCount | int | `1` | Number of cutout worker pods to start |
+| cutoutWorker.replicaCount | int | `2` | Number of cutout worker pods to start |
 | cutoutWorker.resources | object | `{}` | Resource limits and requests for the cutout worker pod |
 | cutoutWorker.tolerations | list | `[]` | Tolerations for the cutout worker pod |
 | databaseWorker.affinity | object | `{}` | Affinity rules for the database worker pod |

--- a/charts/vo-cutouts/README.md
+++ b/charts/vo-cutouts/README.md
@@ -1,6 +1,6 @@
 # vo-cutouts
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Image cutout service complying with IVOA SODA
 
@@ -32,8 +32,8 @@ Image cutout service complying with IVOA SODA
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |
 | cutoutWorker.affinity | object | `{}` | Affinity rules for the cutout worker pod |
 | cutoutWorker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for cutout workers |
-| cutoutWorker.image.repository | string | `"lsstsqre/centos"` | Stack image to use for cutouts |
-| cutoutWorker.image.tag | string | `"7-stack-lsst_distrib-w_2022_06"` | Stack image tag to use |
+| cutoutWorker.image.repository | string | `"lsstsqre/vo-cutouts-worker"` | Stack image to use for cutouts |
+| cutoutWorker.image.tag | string | The appVersion of the chart | Tag of vo-cutouts worker image to use |
 | cutoutWorker.nodeSelector | object | `{}` | Node selection rules for the cutout worker pod |
 | cutoutWorker.podAnnotations | object | `{}` | Annotations for the cutout worker pod |
 | cutoutWorker.replicaCount | int | `2` | Number of cutout worker pods to start |

--- a/charts/vo-cutouts/README.md
+++ b/charts/vo-cutouts/README.md
@@ -26,7 +26,7 @@ Image cutout service complying with IVOA SODA
 | config.butlerRepository | string | None, must be set | Configuration for the Butler repository to use |
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.gcsBucketUrl | string | None, must be set | URL for the GCS bucket into which to store cutouts (must start with `s3`) |
-| config.lifetime | int | 604800 (1 week) | Lifetime of job results in seconds |
+| config.lifetime | int | 2592000 (30 days) | Lifetime of job results in seconds |
 | config.loglevel | string | `"INFO"` | Choose from the text form of Python logging levels |
 | config.syncTimeout | int | 60 (1 minute) | Timeout for results from a sync cutout in seconds |
 | config.timeout | int | 600 (10 minutes) | Timeout for a single cutout job in seconds |

--- a/charts/vo-cutouts/templates/configmap.yaml
+++ b/charts/vo-cutouts/templates/configmap.yaml
@@ -14,3 +14,4 @@ data:
   CUTOUT_REDIS_HOST: "{{ template "vo-cutouts.fullname" . }}-redis.{{ .Release.Namespace }}"
   CUTOUT_SYNC_TIMEOUT: {{ .Values.config.syncTimeout | quote }}
   SAFIR_LOG_LEVEL: {{ .Values.config.loglevel | quote }}
+  SAFIR_PROFILE: "production"

--- a/charts/vo-cutouts/templates/db-worker-deployment.yaml
+++ b/charts/vo-cutouts/templates/db-worker-deployment.yaml
@@ -67,6 +67,8 @@ spec:
             - "vocutouts.actors"
             - "-Q"
             - "uws"
+            - "-p"
+            - "1"
           env:
             - name: "CUTOUT_DATABASE_PASSWORD"
               valueFrom:

--- a/charts/vo-cutouts/templates/ingress.yaml
+++ b/charts/vo-cutouts/templates/ingress.yaml
@@ -6,8 +6,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-method: "GET"
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User
     nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr.gafaelfawr.svc.cluster.local:8080/auth?{{ required "ingress.gafaelfawrAuthQuery must be set" .Values.ingress.gafaelfawrAuthQuery }}"
-    nginx.ingress.kubernetes.io/rewrite-target: "/cutout$1"
-    nginx.ingress.kubernetes.io/use-regex: "true"
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -19,8 +17,8 @@ spec:
     - host: {{ required "ingress.host must be set" .Values.ingress.host | quote }}
       http:
         paths:
-          - path: "/api/cutout(.*)"
-            pathType: "ImplementationSpecific"
+          - path: "/api/cutout"
+            pathType: "Prefix"
             backend:
               service:
                 name: {{ template "vo-cutouts.fullname" . }}

--- a/charts/vo-cutouts/templates/worker-deployment.yaml
+++ b/charts/vo-cutouts/templates/worker-deployment.yaml
@@ -65,57 +65,8 @@ spec:
             capabilities:
               drop:
                 - "all"
-          image: "{{ .Values.cutoutWorker.image.repository }}:{{ .Values.cutoutWorker.image.tag }}"
+          image: "{{ .Values.cutoutWorker.image.repository }}:{{ .Values.cutoutWorker.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.cutoutWorker.image.pullPolicy | quote }}
-
-          # This tricky command bootstraps the worker on every container
-          # restart.  It requires there exist a branch in the vo-cutouts
-          # GitHub repository that matches the tag (changing "tickets-" to
-          # "tickets/") of the Docker image to use, and retrieves the worker
-          # Python file from there.  It then installs Dramatiq and runs it
-          # with the stack Python.
-          #
-          # The current approach requires a writable root file system so that
-          # image_cutout_backend can be installed into the Conda environment.
-          # It will instead be incorporated into the stack in the future so
-          # that we don't have to do all the setup nonsense below and can go
-          # back to using a read-only root file system.  Once that's done, the
-          # invocation of dramatiq must be replaced with:
-          #
-          # python /home/lsst/.local/bin/dramatiq
-          #
-          # because pip will then install new packages into ~/.local.  The
-          # path in the user home directory uesd by pip install run as a
-          # non-root user is in the Python path by default, so packages
-          # installed that way will be picked up by the stack Python.
-          # However, ~/.local/bin is not in PATH and we want to force the
-          # stack Python (which should be first in PATH), so invoke Dramatiq
-          # with an explicit execution of python.
-          #
-          # This approach is probably temporary and will be replaced with a
-          # more reproducible way of getting the worker source.
-          command:
-            - "/bin/bash"
-            - "-c"
-            - |
-              source /opt/lsst/software/stack/loadLSST.bash
-              setup lsst_distrib
-              set -x
-              pip install --no-cache-dir 'dramatiq[redis]'
-              cd /tmp
-              rm -r cutouts
-              mkdir cutouts
-              rm -r image_cutout_backend
-              git clone --depth 1 -b tickets/DM-32097 https://github.com/lsst-dm/image_cutout_backend.git
-              cd image_cutout_backend
-              setup -r .
-              scons install declare -t current
-              cd ..
-              rm -r vo-cutouts
-              git clone --depth 1 -b "$(echo '{{ .Values.image.tag | default .Chart.AppVersion }}' | sed 's,tickets-,tickets/,')" https://github.com/lsst-sqre/vo-cutouts
-              cd vo-cutouts/src/vocutouts
-              dramatiq workers -Q cutout -p 1 -t 1
-
           env:
             # The following are used by Butler to retrieve its configuration
             # and authenticate to its database.
@@ -148,16 +99,11 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: "local"
-              mountPath: "/home/lsst"
             - name: "secrets"
               mountPath: "/etc/vo-cutouts/secrets"
             - name: "tmp"
               mountPath: "/tmp"
       volumes:
-        # The /home/lsst home directory, which is used by pip install.
-        - name: "local"
-          emptyDir: {}
         - name: "secrets"
           emptyDir: {}
         - name: "secrets-raw"

--- a/charts/vo-cutouts/templates/worker-deployment.yaml
+++ b/charts/vo-cutouts/templates/worker-deployment.yaml
@@ -46,12 +46,12 @@ spec:
             - "-c"
             - |
               cp -RL /etc/vo-cutouts/secrets-raw/* /etc/vo-cutouts/secrets
-              chown appuser:appuser /etc/vo-cutouts/secrets/*
               chmod 0400 /etc/vo-cutouts/secrets/*
           securityContext:
-            runAsNonRoot: false
-            runAsUser: 0
-            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "all"
           volumeMounts:
             - name: "secrets"
               mountPath: "/etc/vo-cutouts/secrets"

--- a/charts/vo-cutouts/templates/worker-deployment.yaml
+++ b/charts/vo-cutouts/templates/worker-deployment.yaml
@@ -114,7 +114,7 @@ spec:
               rm -r vo-cutouts
               git clone --depth 1 -b "$(echo '{{ .Values.image.tag | default .Chart.AppVersion }}' | sed 's,tickets-,tickets/,')" https://github.com/lsst-sqre/vo-cutouts
               cd vo-cutouts/src/vocutouts
-              dramatiq workers -Q cutout
+              dramatiq workers -Q cutout -p 1 -t 1
 
           env:
             # The following are used by Butler to retrieve its configuration

--- a/charts/vo-cutouts/values.yaml
+++ b/charts/vo-cutouts/values.yaml
@@ -90,8 +90,8 @@ config:
   timeout: 600
 
   # -- Lifetime of job results in seconds
-  # @default -- 604800 (1 week)
-  lifetime: 604800
+  # @default -- 2592000 (30 days)
+  lifetime: 2592000
 
   # -- Timeout for results from a sync cutout in seconds
   # @default -- 60 (1 minute)

--- a/charts/vo-cutouts/values.yaml
+++ b/charts/vo-cutouts/values.yaml
@@ -130,10 +130,11 @@ cutoutWorker:
 
   image:
     # -- Stack image to use for cutouts
-    repository: "lsstsqre/centos"
+    repository: "lsstsqre/vo-cutouts-worker"
 
-    # -- Stack image tag to use
-    tag: "7-stack-lsst_distrib-w_2022_06"
+    # -- Tag of vo-cutouts worker image to use
+    # @default -- The appVersion of the chart
+    tag: ""
 
     # -- Pull policy for cutout workers
     pullPolicy: "IfNotPresent"

--- a/charts/vo-cutouts/values.yaml
+++ b/charts/vo-cutouts/values.yaml
@@ -126,7 +126,7 @@ cloudsql:
 
 cutoutWorker:
   # -- Number of cutout worker pods to start
-  replicaCount: 1
+  replicaCount: 2
 
   image:
     # -- Stack image to use for cutouts


### PR DESCRIPTION
This is a long list of small changes, which can be reviewed commit by commit if desired.

- Spawn a single database worker process per pod. If we want to scale horizontally, we'll add more pods
- Default to a couple of cutout worker backends, since they are now limited to one process and thread per pod
- Set the vo-cutouts logging style to production for JSON logs
- Align the job lifetime with the bucket lifetime (set to 30 days)
- Stop doing path rewriting in the ingress since the application now exposes `/api/cutout` routes
- Simplify how the permissions on the PostgreSQL secret for the worker backend are fixed
- Use the pre-built worker backend instead of constructing it on the fly during pod startup