### PR TITLE
[DM-33718] Add Gafaelfawr support for UID via LDAP

### DIFF
--- a/charts/gafaelfawr/Chart.yaml
+++ b/charts/gafaelfawr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: gafaelfawr
-version: 4.5.5
+version: 4.6.0
 description: The Gafaelfawr authentication and authorization system
 home: https://gafaelfawr.lsst.io/
 maintainers:
   - name: rra
-appVersion: 3.5.1
+appVersion: 3.6.0

--- a/charts/gafaelfawr/templates/configmap.yaml
+++ b/charts/gafaelfawr/templates/configmap.yaml
@@ -108,7 +108,11 @@ data:
       url: {{ .Values.config.ldap.url | quote }}
       base_dn: {{ required "config.ldap.baseDn must be set" .Values.config.ldap.baseDn | quote }}
       group_object_class: {{ .Values.config.ldap.groupObjectClass | quote }}
-      group_member: {{ .Values.config.ldap.groupMember | quote }}
+      group_member_attr: {{ .Values.config.ldap.groupMemberAttr | quote }}
+      {{- if .Values.config.uidBaseDn }}
+      uid_base_dn: {{ .Values.config.uidBaseDn | quote }}
+      uid_attr: {{ .Values.config.uidAttr | quote }}
+      {{- end }}
     {{- end }}
 
     {{- if .Values.config.oidcServer.enabled }}

--- a/charts/gafaelfawr/values.yaml
+++ b/charts/gafaelfawr/values.yaml
@@ -155,7 +155,15 @@ config:
 
     # -- Member attribute of the object class. Values must match the username
     # returned in the token from the OpenID Connect authentication server.
-    groupMember: "member"
+    groupMemberAttr: "member"
+
+    # -- Base DN for the LDAP search to find a user's UID number
+    # @default -- Get the UID number from the upstream authentication provider
+    uidBaseDn: ""
+
+    # -- Attribute containing the user's UID number (only used if uidBaseDn is
+    # set)
+    uidAttr: "uidNumber"
 
   issuer:
     # -- Session length and token expiration (in minutes)


### PR DESCRIPTION
Add Helm configuration to retrieve the user's UID via LDAP instead
of from an OpenID Connect JWT.  Update the application verison to
3.6.0.