### PR TITLE
[DM-33720] Quote vo-cutouts job lifetime

### DIFF
--- a/charts/vo-cutouts/Chart.yaml
+++ b/charts/vo-cutouts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vo-cutouts
-version: 0.3.0
+version: 0.3.1
 description: Image cutout service complying with IVOA SODA
 home: https://github.com/lsst-sqre/vo-cutouts
 maintainers:

--- a/charts/vo-cutouts/values.yaml
+++ b/charts/vo-cutouts/values.yaml
@@ -89,9 +89,10 @@ config:
   # @default -- 600 (10 minutes)
   timeout: 600
 
-  # -- Lifetime of job results in seconds
+  # -- Lifetime of job results in seconds (quote so that Helm doesn't turn it
+  # into a floating point number)
   # @default -- 2592000 (30 days)
-  lifetime: 2592000
+  lifetime: "2592000"
 
   # -- Timeout for results from a sync cutout in seconds
   # @default -- 60 (1 minute)


### PR DESCRIPTION
Otherwise, Helm turns it into a floating point number, which then
breaks the application.