### PR TITLE
Fix the vo-cutouts readiness probe URL, secret permissions

### DIFF
--- a/charts/vo-cutouts/Chart.yaml
+++ b/charts/vo-cutouts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vo-cutouts
-version: 0.3.1
+version: 0.3.2
 description: Image cutout service complying with IVOA SODA
 home: https://github.com/lsst-sqre/vo-cutouts
 maintainers:

--- a/charts/vo-cutouts/templates/deployment.yaml
+++ b/charts/vo-cutouts/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
                 name: {{ template "vo-cutouts.fullname" . }}-config
           readinessProbe:
             httpGet:
-              path: "/cutout/availability"
+              path: "/api/cutout/availability"
               port: "http"
           {{- with .Values.resources }}
           resources:

--- a/charts/vo-cutouts/templates/worker-deployment.yaml
+++ b/charts/vo-cutouts/templates/worker-deployment.yaml
@@ -109,7 +109,6 @@ spec:
         - name: "secrets-raw"
           secret:
             secretName: {{ template "vo-cutouts.fullname" . }}-secret
-            defaultMode: 0400
         - name: "tmp"
           emptyDir: {}
       {{- with .Values.cutoutWorker.nodeSelector }}


### PR DESCRIPTION
The application now expects the /api prefix. The secrets now need to be world-readable.