### PR TITLE
tickets/DM-33044: adopt JH 2.x

### DIFF
--- a/charts/cachemachine/Chart.yaml
+++ b/charts/cachemachine/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cachemachine
-version: 1.2.2
+version: 1.2.3
 description: Service to prepull Docker images for the Science Platform
 maintainers:
   - name: cbanek
-appVersion: 1.1.0
+appVersion: 1.1.1

--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nublado2
-version: 0.7.0
-appVersion: "1.6.0"
+version: 0.8.0
+appVersion: "2.0.0"
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2
 maintainers:
@@ -12,5 +12,5 @@ sources:
 kubeVersion: ">=1.16.0-0"
 dependencies:
   - name: jupyterhub
-    version: "1.1.4"
+    version: "1.1.3-n324.hb93a9b5f"
     repository: https://jupyterhub.github.io/helm-chart/

--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -12,5 +12,5 @@ sources:
 kubeVersion: ">=1.16.0-0"
 dependencies:
   - name: jupyterhub
-    version: "1.1.3-n324.hb93a9b5f"
+    version: "1.1.3-n324.hb93a9b5f"  # Change when JH 2.1.1 chart is official
     repository: https://jupyterhub.github.io/helm-chart/

--- a/charts/nublado2/Chart.yaml
+++ b/charts/nublado2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: nublado2
-version: 0.8.0
-appVersion: "2.0.0"
+version: 0.8.1
+appVersion: "2.0.1"
 description: Nublado2 JupyterHub installation
 home: https://github.com/lsst-sqre/nublado2
 maintainers:

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -12,6 +12,8 @@ jupyterhub:
         enable_auth_state: true
       JupyterHub:
         authenticator_class: nublado2.auth.GafaelfawrAuthenticator
+      ServerApp:
+        shutdown_no_activity_timeout: 604800  # one week
     db:
       # Password comes from the nublado2-secret.
       type: "postgres"
@@ -50,6 +52,11 @@ jupyterhub:
     #  you explicitly enable port 8081 so the labs can talk to the Hub.
     networkPolicy:
       enabled: false
+    loadRoles:
+      self:
+        scopes: ['admin:servers!user']  # Create and delete
+      server:
+        scopes: ['inherit']  # Let server use API like user
 
   prePuller:
     continuous:
@@ -157,10 +164,13 @@ jupyterhub:
         error_page 403 = "/auth/forbidden?scope=exec:notebook";
     pathSuffix: "*"
 
-  # The default culler setting is enabled, with 3600s idle.  This is way
-  #  too short for our purposes.  First cut: just disable it.
   cull:
-    enabled: false
+    enabled: true
+    timeout: 2592000  # 30 days -- shorten later
+    every: 600 # Check every ten minutes
+    users: true  # log out user when we cull
+    removeNamedServers: true
+    maxAge: 5184000  # 60 days -- shorten later
 
   imagePullSecrets:
     - name: pull-secret

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -6,7 +6,7 @@ jupyterhub:
   hub:
     image:
       name: lsstsqre/nublado2
-      tag: "1.6.0"
+      tag: "2.0.0"
     config:
       Authenticator:
         enable_auth_state: true

--- a/charts/nublado2/values.yaml
+++ b/charts/nublado2/values.yaml
@@ -167,9 +167,9 @@ jupyterhub:
   cull:
     enabled: true
     timeout: 2592000  # 30 days -- shorten later
-    every: 600 # Check every ten minutes
+    every: 600  # Check every ten minutes
     users: true  # log out user when we cull
-    removeNamedServers: true
+    removeNamedServers: true  # Post-stop hook may already do this
     maxAge: 5184000  # 60 days -- shorten later
 
   imagePullSecrets:


### PR DESCRIPTION
JH 2.1.1 plus custom (asyncio) kubespawner, plus culler-enabling with long timeout to prepare for Dan's culler rework.