### PR TITLE
DM-33627: Times Square 0.1.6 chart fixes

### DIFF
--- a/charts/times-square/Chart.yaml
+++ b/charts/times-square/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     url: https://github.com/jonathansick
 
 # The chart version.
-version: 0.1.5
+version: 0.1.6
 
 # The app's version corresponding to the image tag.
 appVersion: "0.1.0"

--- a/charts/times-square/README.md
+++ b/charts/times-square/README.md
@@ -1,6 +1,6 @@
 # times-square
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A parameterized notebook web viewer for the Rubin Science Platform.
 
@@ -38,12 +38,11 @@ A parameterized notebook web viewer for the Rubin Science Platform.
 | config.databaseUrl | string | None, must be set | URL for the PostgreSQL database |
 | config.environmentUrl | string | None, must be set | RSP hostname, for computing internal service URLs |
 | config.logLevel | string | `"INFO"` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" |
-| config.loggerName | string | `"times-square"` | Logger name |
 | config.name | string | `"times-square"` | Name of the service. |
 | config.profile | string | `"production"` | Run profile: "production" or "development" |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `"Always"` | Pull policy for the times-square image |
-| image.repository | string | `"lsstsqre/timessquare"` | Image to use in the times-square deployment |
+| image.repository | string | `"lsstsqre/times-square"` | Image to use in the times-square deployment |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Secret names to use for all Docker pulls |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress rule |

--- a/charts/times-square/serviceaccount.yaml
+++ b/charts/times-square/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if or .Values.serviceAccount.create .Values.cloudsql.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "times-square.serviceAccountName" . }}
+  labels:
+    {{- include "times-square.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.cloudsql.enabled }}
+    iam.gke.io/gcp-service-account: {{ required "cloudsql.serviceAccount must be set to a valid Google service account" .Values.cloudsql.serviceAccount | quote }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/times-square/values.yaml
+++ b/charts/times-square/values.yaml
@@ -109,9 +109,6 @@ config:
   # -- Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
   logLevel: "INFO"
 
-  # -- Logger name
-  loggerName: "times-square"
-
   # -- RSP hostname, for computing internal service URLs
   # @default -- None, must be set
   environmentUrl: ""

--- a/charts/times-square/values.yaml
+++ b/charts/times-square/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   # -- Image to use in the times-square deployment
-  repository: lsstsqre/timessquare
+  repository: lsstsqre/times-square
 
   # -- Pull policy for the times-square image
   pullPolicy: Always


### PR DESCRIPTION
Fixes for the times-square chart:

- add ServiceAccount template to support Cloud SQL
- Update name of TS's Docker image