### PR TITLE
[DM-34074] Ability to set publish URL

### DIFF
--- a/charts/sherlock/Chart.yaml
+++ b/charts/sherlock/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.1.3
+appVersion: 0.1.4
 description: A Helm chart for Kubernetes
 name: sherlock
 type: application
-version: 0.1.6
+version: 0.1.7
 maintainers:
   - name: cbanek

--- a/charts/sherlock/templates/deployment.yaml
+++ b/charts/sherlock/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             readOnlyRootFilesystem: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: "PUBLISH_URL"
+              value: {{ .Values.publish_url }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/sherlock/values.yaml
+++ b/charts/sherlock/values.yaml
@@ -81,3 +81,6 @@ affinity: {}
 
 serviceAccount:
   name: ""
+
+# -- URL to push status to via HTTP PUTs.
+publish_url: ""


### PR DESCRIPTION
This allows for the configuration of the publish URL for
sherlock to publish its status to.