### PR TITLE
[DM-34433] Sherlock: Set cors headers

### DIFF
--- a/charts/sherlock/Chart.yaml
+++ b/charts/sherlock/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: 0.1.6
 description: A Helm chart for Kubernetes
 name: sherlock
 type: application
-version: 0.1.11
+version: 0.1.12
 maintainers:
   - name: cbanek

--- a/charts/sherlock/templates/ingress.yaml
+++ b/charts/sherlock/templates/ingress.yaml
@@ -13,6 +13,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Token
     nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.ingress.host }}/login"
     nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.ingress.host }}/auth?{{ .Values.ingress.gafaelfawrAuthQuery }}"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
     {{- end }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Okay so this should inject the cors headers, and I'll get rid of the
code that generates the cors headers from the sherlock code.

Unfortunately, setting the list of domains doesn't seem to work.
This means that I can't set the host to just status.lsst.codes, instead
the default is *, which isn't great, but isn't terrible.

nginx.ingress.kubernetes.io/cors-allow-origin is the annotation
that is supposed to work, but when I set it it does not work.