### PR TITLE
DM-37390: Simplify Redis persistent storage name

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: redis
-version: 0.1.1
+version: 0.1.2
 description: Simple single-server Redis deployment with configurable storage
 sources:
   - https://github.com/lsst-sqre/charts/tree/master/charts/redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -93,7 +93,7 @@ spec:
   {{- if (and .Values.persistence.enabled (not .Values.persistence.volumeClaimName)) }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ template "redis.fullname" . }}
+        name: "storage"
       spec:
         accessModes:
           - {{ .Values.persistence.accessMode | quote }}


### PR DESCRIPTION
It looks like the StatefulSet always prepends its own name to the storage, so avoid repeating that name and make the PVC name shorter.