### PR TITLE
DM-37390: Fix Redis StatefulSet volume reference

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: redis
-version: 0.1.2
+version: 0.1.3
 description: Simple single-server Redis deployment with configurable storage
 sources:
   - https://github.com/lsst-sqre/charts/tree/master/charts/redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
                 - "all"
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: {{ template "redis.fullname" . }}
+            - name: "storage"
               mountPath: "/data"
       securityContext:
         fsGroup: 999


### PR DESCRIPTION
I renamed the volume template but not the reference to it.