### PR TITLE
DM-37390: Improvements for non-persistent Redis

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: redis
-version: 0.1.3
+version: 0.1.4
 description: Simple single-server Redis deployment with configurable storage
 sources:
   - https://github.com/lsst-sqre/charts/tree/master/charts/redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -24,8 +24,10 @@ spec:
         - name: "redis"
           args:
             - "redis-server"
+            {{- if .Values.persistence.enabled }}
             - "--appendonly"
             - "yes"
+            {{- end }}
             {{- if (and .Values.config.secretName .Values.config.secretKey) }}
             - "--requirepass"
             - "$(REDIS_PASSWORD)"
@@ -70,11 +72,11 @@ spec:
         runAsGroup: 999
       {{- if (not .Values.persistence.enabled) }}
       volumes:
-        - name: {{ template "redis.fullname" . }}
+        - name: "storage"
           emptyDir: {}
       {{- else if .Values.persistence.volumeClaimName }}
       volumes:
-        - name: {{ template "redis.fullname" . }}
+        - name: "storage"
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.volumeClaimName | quote }}
       {{- end }}


### PR DESCRIPTION
If no persistence is enabled, don't bother enabling the append storage mechanism.  Fix the name of the volume used in cases where we're not creating a new PVC as part of the StatefulSet.