### PR TITLE
DM-37516: Don't use appVersion for redis chart

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
 name: redis
-version: 1.0.0
+version: 1.0.1
 description: Simple single-server Redis deployment with configurable storage
 sources:
   - https://github.com/lsst-sqre/charts/tree/main/charts/redis
 maintainers:
   - name: rra
-appVersion: 7.0.5

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -1,6 +1,6 @@
 # redis
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 7.0.5](https://img.shields.io/badge/AppVersion-7.0.5-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
 
 Simple single-server Redis deployment with configurable storage
 
@@ -24,7 +24,7 @@ Simple single-server Redis deployment with configurable storage
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the Redis image |
 | image.repository | string | `"redis"` | Redis image to use |
-| image.tag | string | The appVersion of the chart | Redis image tag to use |
+| image.tag | string | `"7.0.7"` | Redis image tag to use |
 | nameOverride | string | `""` | Override the base name for resources |
 | nodeSelector | object | `{}` | Node selector rules for the Redis pod |
 | persistence.accessMode | string | `"ReadWriteOnce"` | Access mode of storage to request |

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -11,8 +11,7 @@ image:
   repository: "redis"
 
   # -- Redis image tag to use
-  # @default -- The appVersion of the chart
-  tag: ""
+  tag: "7.0.7"
 
   # -- Pull policy for the Redis image
   pullPolicy: "IfNotPresent"


### PR DESCRIPTION
Move the tag of the Redis version to install into values.yaml so that Renovate will update it for us automatically.  appVersion isn't checked or understood by Renovate.