### PR TITLE
adding missing namespace field in service account and deployment

### DIFF
--- a/charts/strimzi-registry-operator/templates/deployment.yaml
+++ b/charts/strimzi-registry-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: strimzi-registry-operator
+  namespace: {{ .Values.clusterNamespace }}
 spec:
   replicas: 1
   strategy:

--- a/charts/strimzi-registry-operator/templates/rbac.yaml
+++ b/charts/strimzi-registry-operator/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: strimzi-registry-operator
+  namespace: {{ .Values.clusterNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Without these registry is always deployed in default namespace. 