### PR TITLE
[DM-52270] Remove deprecated field in CRD spec

### DIFF
--- a/charts/strimzi-registry-operator/Chart.yaml
+++ b/charts/strimzi-registry-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: strimzi-registry-operator
-version: 2.1.1
+version: 2.1.2
 description: Operator to create and manage a Confluent Schema Registry in a Strimzi-managed Kafka cluster.
 home: https://github.com/lsst-sqre/strimzi-registry-operator
 type: application

--- a/charts/strimzi-registry-operator/README.md
+++ b/charts/strimzi-registry-operator/README.md
@@ -1,6 +1,6 @@
 # strimzi-registry-operator
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Operator to create and manage a Confluent Schema Registry in a Strimzi-managed Kafka cluster.
 

--- a/charts/strimzi-registry-operator/crds/registry.yaml
+++ b/charts/strimzi-registry-operator/crds/registry.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   scope: Namespaced
   group: roundtable.lsst.codes
-  preserveUnknownFields: false
   versions:
     - name: v1beta1
       served: true


### PR DESCRIPTION
- spec.preserveUnknownFields has been deprecated in apiextensions.k8s.io/v1
- Bump chart version to 2.1.2