### PR TITLE
DM-55808: Add maxmemory configuration support to redis

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: redis
-version: 1.1.14
+version: 1.2.0
 description: Simple single-server Redis deployment with configurable storage
 sources:
   - https://github.com/lsst-sqre/charts/tree/main/charts/redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -1,6 +1,6 @@
 # redis
 
-![Version: 1.1.14](https://img.shields.io/badge/Version-1.1.14-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square)
 
 Simple single-server Redis deployment with configurable storage
 
@@ -19,6 +19,8 @@ Simple single-server Redis deployment with configurable storage
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for the Redis pod |
+| config.maxMemory | string | Do not set a limit | Maximum memory to use for cached data. An `mb` suffix can be used to indicate MiB. For Redis with persistent storage, this should be set to somewhat less than the available memory. See [the Redis documentation](https://redis.io/docs/latest/develop/reference/eviction/#maxmem) for more details. |
+| config.maxMemoryPolicy | string | Do not set an eviction policy. | Eviction policy. Only meaningful in combination with `maxMemory`. See [the Redis documentation](https://redis.io/docs/latest/develop/reference/eviction/#eviction-policies) for more details. |
 | config.secretKey | string | Do not require authentication | Key inside secret from which to get the Redis password. If set, `config.secretName` must also be set. |
 | config.secretName | string | Do not require authentication | Name of secret from which to get the Redis password. If set, `config.secretKey` must also be set. |
 | fullnameOverride | string | `""` | Override the full name for resources (includes the release name) |

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -32,6 +32,14 @@ spec:
             - "--requirepass"
             - "$(REDIS_PASSWORD)"
             {{- end }}
+            {{- if .Values.config.maxMemory }}
+            - "--maxmemory"
+            - {{ .Values.config.maxMemory | quote }}
+            {{- end }}
+            {{- if .Values.config.maxMemoryPolicy }}
+            - "--maxmemory-policy"
+            - {{ .Values.config.maxMemoryPolicy | quote }}
+            {{- end }}
           {{- if (and .Values.config.secretName .Values.config.secretKey) }}
           env:
             - name: "REDIS_PASSWORD"

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -17,6 +17,21 @@ image:
   pullPolicy: "IfNotPresent"
 
 config:
+  # -- Maximum memory to use for cached data. An `mb` suffix can be used to
+  # indicate MiB. For Redis with persistent storage, this should be set to
+  # somewhat less than the available memory. See [the Redis
+  # documentation](https://redis.io/docs/latest/develop/reference/eviction/#maxmem)
+  # for more details.
+  # @default -- Do not set a limit
+  maxMemory: ""
+
+  # -- Eviction policy. Only meaningful in combination with `maxMemory`. See
+  # [the Redis
+  # documentation](https://redis.io/docs/latest/develop/reference/eviction/#eviction-policies)
+  # for more details.
+  # @default -- Do not set an eviction policy.
+  maxMemoryPolicy: ""
+
   # -- Name of secret from which to get the Redis password. If set,
   # `config.secretKey` must also be set.
   # @default -- Do not require authentication


### PR DESCRIPTION
Add support for configuring `maxmemory` and `maxmemory-policy` to the Redis chart.